### PR TITLE
feat(ci): add staging environment deployment workflow

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,155 @@
+name: Deploy Staging
+
+on:
+  push:
+    branches: [develop]
+
+concurrency:
+  group: staging
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ${{ github.repository }}
+
+jobs:
+  # ── 1. Run full test suite before deploying ──────────────────────────────────
+  test:
+    name: Test Suite
+    uses: ./.github/workflows/ci.yml
+
+  # ── 2. Build & push Docker images ────────────────────────────────────────────
+  build:
+    name: Build Images
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      backend_image:  ${{ steps.meta-backend.outputs.tags }}
+      frontend_image: ${{ steps.meta-frontend.outputs.tags }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta — backend
+        id: meta-backend
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/backend
+          tags: |
+            type=sha,prefix=staging-
+            type=raw,value=staging-latest
+
+      - name: Docker meta — frontend
+        id: meta-frontend
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/frontend
+          tags: |
+            type=sha,prefix=staging-
+            type=raw,value=staging-latest
+
+      - name: Build & push backend
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          push: true
+          tags: ${{ steps.meta-backend.outputs.tags }}
+
+      - name: Build & push frontend
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          push: true
+          tags: ${{ steps.meta-frontend.outputs.tags }}
+          build-args: |
+            NEXT_PUBLIC_API_URL=${{ secrets.STAGING_API_URL }}
+            NEXT_PUBLIC_STELLAR_NETWORK=testnet
+            NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
+            NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+            NEXT_PUBLIC_REGISTRY_CONTRACT=${{ secrets.STAGING_REGISTRY_CONTRACT_ID }}
+            NEXT_PUBLIC_CREDIT_CONTRACT=${{ secrets.STAGING_CREDIT_CONTRACT_ID }}
+            NEXT_PUBLIC_MARKETPLACE_CONTRACT=${{ secrets.STAGING_MARKETPLACE_CONTRACT_ID }}
+            NEXT_PUBLIC_ORACLE_CONTRACT=${{ secrets.STAGING_ORACLE_CONTRACT_ID }}
+            NEXT_PUBLIC_USDC_CONTRACT=${{ secrets.STAGING_USDC_CONTRACT_ID }}
+
+  # ── 3. Deploy to staging server ───────────────────────────────────────────────
+  deploy:
+    name: Deploy to Staging
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: staging
+      url: ${{ secrets.STAGING_URL }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host:     ${{ secrets.STAGING_SSH_HOST }}
+          username: ${{ secrets.STAGING_SSH_USER }}
+          key:      ${{ secrets.STAGING_SSH_KEY }}
+          script: |
+            set -e
+            cd /opt/carbonledger-staging
+
+            # Pull latest compose file
+            git fetch origin develop
+            git checkout origin/develop -- docker-compose.yml docker-compose.staging.yml
+
+            # Inject image tags
+            export BACKEND_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/backend:staging-latest"
+            export FRONTEND_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/frontend:staging-latest"
+
+            # Pull new images and restart
+            docker compose -f docker-compose.yml -f docker-compose.staging.yml pull
+            docker compose -f docker-compose.yml -f docker-compose.staging.yml up -d --remove-orphans
+
+            # Run migrations
+            docker compose -f docker-compose.yml -f docker-compose.staging.yml \
+              exec -T backend npx prisma migrate deploy
+
+            # Seed staging DB if first deploy
+            if [ -f .seed_needed ]; then
+              docker compose -f docker-compose.yml -f docker-compose.staging.yml \
+                exec -T backend npx ts-node prisma/seed-staging.ts
+              rm .seed_needed
+            fi
+
+  # ── 4. Smoke test ─────────────────────────────────────────────────────────────
+  smoke:
+    name: Smoke Test
+    needs: deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Wait for staging to be ready
+        run: sleep 20
+
+      - name: Health check — backend
+        run: |
+          curl --fail --retry 5 --retry-delay 5 \
+            "${{ secrets.STAGING_API_URL }}/health" \
+            -H "Accept: application/json"
+
+      - name: Health check — frontend
+        run: |
+          curl --fail --retry 5 --retry-delay 5 \
+            "${{ secrets.STAGING_URL }}"
+
+      - name: Verify Testnet contract IDs are set
+        run: |
+          RESPONSE=$(curl -s "${{ secrets.STAGING_API_URL }}/health")
+          echo "$RESPONSE" | grep -q '"stellar_network":"testnet"' || \
+            (echo "Staging is not pointing at testnet!" && exit 1)

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { Module, Controller, Get } from "@nestjs/common";
 import { AuthModule } from "./auth/auth.module";
 import { ProjectsModule } from "./projects/projects.module";
 import { CreditsModule } from "./credits/credits.module";
@@ -7,6 +7,18 @@ import { MarketplaceModule } from "./marketplace/marketplace.module";
 import { OracleModule } from "./oracle/oracle.module";
 import { StatsModule } from "./stats/stats.module";
 import { PrismaService } from "./prisma.service";
+
+@Controller("health")
+class HealthController {
+  @Get()
+  check() {
+    return {
+      status: "ok",
+      stellar_network: process.env.STELLAR_NETWORK || "testnet",
+      timestamp: new Date().toISOString(),
+    };
+  }
+}
 
 @Module({
   imports: [
@@ -18,6 +30,7 @@ import { PrismaService } from "./prisma.service";
     OracleModule,
     StatsModule,
   ],
+  controllers: [HealthController],
   providers: [PrismaService],
 })
 export class AppModule {}

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,37 @@
+# Staging overrides — merged on top of docker-compose.yml
+# Usage: docker compose -f docker-compose.yml -f docker-compose.staging.yml up -d
+
+version: "3.9"
+
+services:
+  postgres:
+    environment:
+      POSTGRES_DB:       carbonledger_staging
+      POSTGRES_USER:     carbonledger
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - postgres_staging_data:/var/lib/postgresql/data
+
+  backend:
+    image: ${BACKEND_IMAGE:-ghcr.io/carbonledger/backend:staging-latest}
+    environment:
+      DATABASE_URL:                    postgresql://carbonledger:${POSTGRES_PASSWORD}@postgres:5432/carbonledger_staging
+      JWT_SECRET:                      ${JWT_SECRET}
+      STELLAR_NETWORK:                 testnet
+      STELLAR_RPC_URL:                 https://soroban-testnet.stellar.org
+      CARBON_REGISTRY_CONTRACT_ID:     ${STAGING_REGISTRY_CONTRACT_ID}
+      CARBON_CREDIT_CONTRACT_ID:       ${STAGING_CREDIT_CONTRACT_ID}
+      CARBON_MARKETPLACE_CONTRACT_ID:  ${STAGING_MARKETPLACE_CONTRACT_ID}
+      CARBON_ORACLE_CONTRACT_ID:       ${STAGING_ORACLE_CONTRACT_ID}
+      USDC_CONTRACT_ID:                ${STAGING_USDC_CONTRACT_ID}
+      REDIS_HOST:                      redis
+      REDIS_PORT:                      6379
+      REDIS_PASSWORD:                  ${REDIS_PASSWORD:-}
+      FRONTEND_URL:                    ${STAGING_URL}
+      PORT:                            3001
+
+  frontend:
+    image: ${FRONTEND_IMAGE:-ghcr.io/carbonledger/frontend:staging-latest}
+
+volumes:
+  postgres_staging_data:


### PR DESCRIPTION

**Title:** feat(ci): add persistent staging environment deployment workflow

**Description:**

Deploys a persistent staging environment (Stellar Testnet + staging DB + staging backend) automatically on every merge to `develop`.

### Changes
- `.github/workflows/staging.yml` — triggered on push to `develop`:
  1. Runs full test suite (reuses `ci.yml`)
  2. Builds and pushes backend + frontend Docker images to GHCR
  3. Deploys to staging server via SSH: `docker compose pull && up && prisma migrate deploy`
  4. Seeds staging DB on first deploy (checks `.seed_needed` flag)
  5. Smoke tests: `GET /health`, frontend URL, verifies `stellar_network=testnet`
- `docker-compose.staging.yml` — override file with staging DB name, testnet contract IDs, and GHCR image tags
- `GET /api/v1/health` endpoint added to backend returning `{ status, stellar_network, timestamp }`

### Required GitHub secrets (`staging` environment)
| Secret | Description |
|---|---|
| `STAGING_SSH_HOST` | Staging server IP/hostname |
| `STAGING_SSH_USER` | SSH username |
| `STAGING_SSH_KEY` | SSH private key |
| `STAGING_URL` | Public staging URL |
| `STAGING_API_URL` | Staging backend API URL |
| `STAGING_*_CONTRACT_ID` | Testnet contract IDs |
| `POSTGRES_PASSWORD` | Staging DB password |
| `JWT_SECRET` | JWT signing secret |

Closes #70
