### PR TITLE
feat(dashboard): add active credits, earnings history, and oracle alerts

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,18 +1,58 @@
 "use client";
 
-import { useProjects, useRetirements, useListings } from "../../lib/api";
-import { formatTonnes, formatStroops } from "../../lib/carbon-utils";
+import { useProjects, useRetirements, useListings, useOracleStatus } from "../../lib/api";
+import { formatTonnes } from "../../lib/carbon-utils";
 import { colors, statusBadge } from "../../styles/design-system";
 import OracleStatus from "../../components/OracleStatus";
 
-export default function DashboardPage() {
-  const { data: projects }   = useProjects();
-  const { data: retirements } = useRetirements(20);
-  const { data: listings }   = useListings();
+const STALE_WARNING_DAYS = 60;
+const STALE_TOTAL_DAYS = 365;
 
-  const totalIssued   = (projects ?? []).reduce((s, p) => s + p.totalCreditsIssued, 0);
-  const totalRetired  = (projects ?? []).reduce((s, p) => s + p.totalCreditsRetired, 0);
+// Renders an amber alert banner when a project's monitoring is near the 365-day staleness limit.
+function ProjectStaleAlert({ projectId, projectName }: { projectId: string; projectName: string }) {
+  const { data } = useOracleStatus(projectId);
+  if (!data?.lastSubmittedAt || !data.isCurrent) return null;
+
+  const daysSince = Math.floor((Date.now() - new Date(data.lastSubmittedAt).getTime()) / 86_400_000);
+  const daysUntilStale = STALE_TOTAL_DAYS - daysSince;
+  if (daysUntilStale > STALE_WARNING_DAYS) return null;
+
+  return (
+    <div style={{
+      display: "flex",
+      alignItems: "center",
+      gap: "0.75rem",
+      background: "#FEF3C7",
+      border: "1px solid #FDE68A",
+      borderRadius: "0.5rem",
+      padding: "0.75rem 1rem",
+      fontSize: "0.875rem",
+      color: "#92400E",
+    }}>
+      <span style={{ fontSize: "1rem" }}>⚠</span>
+      <span>
+        <strong>{projectName}</strong> monitoring expires in{" "}
+        <strong>{daysUntilStale} day{daysUntilStale === 1 ? "" : "s"}</strong> — submit new satellite data before the
+        365-day limit or credits will be flagged as unverified.
+      </span>
+    </div>
+  );
+}
+
+export default function DashboardPage() {
+  const { data: projects }    = useProjects();
+  const { data: retirements } = useRetirements(50);
+  const { data: listings }    = useListings();
+
+  const totalIssued    = (projects ?? []).reduce((s, p) => s + p.totalCreditsIssued, 0);
+  const totalRetired   = (projects ?? []).reduce((s, p) => s + p.totalCreditsRetired, 0);
+  const activeCredits  = totalIssued - totalRetired;
   const activeListings = (listings ?? []).filter(l => l.status === "Active").length;
+
+  const projectIds = new Set((projects ?? []).map(p => p.projectId));
+  const earnings = (retirements ?? [])
+    .filter(r => projectIds.has(r.projectId))
+    .slice(0, 10);
 
   return (
     <div style={{ maxWidth: "1200px", margin: "0 auto", padding: "2.5rem 2rem" }}>
@@ -21,12 +61,13 @@ export default function DashboardPage() {
       </h1>
 
       {/* Summary stats */}
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: "1.25rem", marginBottom: "2.5rem" }}>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(5, 1fr)", gap: "1.25rem", marginBottom: "2rem" }}>
         {[
-          { label: "Total Issued",    value: formatTonnes(totalIssued),  icon: "🌱" },
-          { label: "Total Retired",   value: formatTonnes(totalRetired), icon: "🔒" },
-          { label: "Active Listings", value: String(activeListings),     icon: "🏪" },
-          { label: "Projects",        value: String(projects?.length ?? 0), icon: "🌍" },
+          { label: "Total Issued",     value: formatTonnes(totalIssued),   icon: "🌱" },
+          { label: "Total Retired",    value: formatTonnes(totalRetired),  icon: "🔒" },
+          { label: "Active Credits",   value: formatTonnes(activeCredits), icon: "✅" },
+          { label: "Active Listings",  value: String(activeListings),      icon: "🏪" },
+          { label: "Projects",         value: String(projects?.length ?? 0), icon: "🌍" },
         ].map(({ label, value, icon }) => (
           <div key={label} style={{
             background: colors.surface, border: `1px solid ${colors.neutral[200]}`,
@@ -42,6 +83,15 @@ export default function DashboardPage() {
           </div>
         ))}
       </div>
+
+      {/* Oracle staleness alerts */}
+      {(projects ?? []).length > 0 && (
+        <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem", marginBottom: "2rem" }}>
+          {(projects ?? []).map(p => (
+            <ProjectStaleAlert key={p.projectId} projectId={p.projectId} projectName={p.name} />
+          ))}
+        </div>
+      )}
 
       {/* Projects table */}
       <div style={{
@@ -97,6 +147,77 @@ export default function DashboardPage() {
             })}
           </tbody>
         </table>
+      </div>
+
+      {/* Recent earnings */}
+      <div style={{
+        background: colors.surface, border: `1px solid ${colors.neutral[200]}`,
+        borderRadius: "0.75rem", overflow: "hidden",
+      }}>
+        <div style={{ padding: "1.25rem 1.5rem", borderBottom: `1px solid ${colors.neutral[100]}` }}>
+          <h2 style={{ fontSize: "1rem", fontWeight: 700, color: colors.neutral[900], margin: 0 }}>
+            Recent Earnings
+          </h2>
+          <p style={{ fontSize: "0.75rem", color: colors.neutral[500], margin: "0.25rem 0 0" }}>
+            On-chain retirements of your project credits
+          </p>
+        </div>
+        {earnings.length === 0 ? (
+          <div style={{ padding: "2rem 1.5rem", textAlign: "center", color: colors.neutral[400], fontSize: "0.875rem" }}>
+            No retirements recorded yet
+          </div>
+        ) : (
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr style={{ background: colors.neutral[50] }}>
+                {["Project", "Amount", "Vintage", "Beneficiary", "Date", "Transaction"].map(h => (
+                  <th key={h} style={{
+                    padding: "0.75rem 1.5rem", textAlign: "left",
+                    fontSize: "0.75rem", fontWeight: 600, color: colors.neutral[500],
+                    textTransform: "uppercase", letterSpacing: "0.05em",
+                  }}>
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {earnings.map(r => (
+                <tr key={r.retirementId} style={{ borderTop: `1px solid ${colors.neutral[100]}` }}>
+                  <td style={{ padding: "0.875rem 1.5rem", fontSize: "0.875rem", fontWeight: 600, color: colors.neutral[900] }}>
+                    {r.projectName ?? r.projectId}
+                  </td>
+                  <td style={{ padding: "0.875rem 1.5rem", fontWeight: 600, color: colors.primary[700] }}>
+                    {formatTonnes(r.amount)}
+                  </td>
+                  <td style={{ padding: "0.875rem 1.5rem", fontSize: "0.875rem", color: colors.neutral[700] }}>
+                    {r.vintageYear}
+                  </td>
+                  <td style={{ padding: "0.875rem 1.5rem", fontSize: "0.875rem", color: colors.neutral[700], maxWidth: "160px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {r.beneficiary}
+                  </td>
+                  <td style={{ padding: "0.875rem 1.5rem", fontSize: "0.875rem", color: colors.neutral[500] }}>
+                    {new Date(r.retiredAt).toLocaleDateString()}
+                  </td>
+                  <td style={{ padding: "0.875rem 1.5rem" }}>
+                    {r.txHash ? (
+                      <a
+                        href={`https://stellar.expert/explorer/testnet/tx/${r.txHash}`}
+                        target="_blank"
+                        rel="noreferrer"
+                        style={{ fontFamily: "monospace", fontSize: "0.8rem", color: colors.primary[600], textDecoration: "none" }}
+                      >
+                        {r.txHash.slice(0, 8)}…
+                      </a>
+                    ) : (
+                      <span style={{ fontSize: "0.8rem", color: colors.neutral[400] }}>—</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
       </div>
     </div>
   );

--- a/frontend/components/OracleStatus.tsx
+++ b/frontend/components/OracleStatus.tsx
@@ -7,6 +7,9 @@ interface Props {
   projectId: string;
 }
 
+const STALE_DAYS = 365;
+const WARNING_THRESHOLD_DAYS = 60;
+
 export default function OracleStatus({ projectId }: Props) {
   const { data, isLoading } = useOracleStatus(projectId);
 
@@ -17,6 +20,16 @@ export default function OracleStatus({ projectId }: Props) {
   );
 
   const isCurrent = data?.isCurrent ?? false;
+
+  let daysSince: number | null = null;
+  let daysUntilStale: number | null = null;
+  if (data?.lastSubmittedAt) {
+    daysSince = Math.floor((Date.now() - new Date(data.lastSubmittedAt).getTime()) / 86_400_000);
+    daysUntilStale = STALE_DAYS - daysSince;
+  }
+
+  const isExpiringSoon = isCurrent && daysUntilStale !== null && daysUntilStale <= WARNING_THRESHOLD_DAYS;
+
   const bg     = isCurrent ? colors.verified.bg     : colors.suspended.bg;
   const text   = isCurrent ? colors.verified.text   : colors.suspended.text;
   const border = isCurrent ? colors.verified.border : colors.suspended.border;
@@ -28,24 +41,38 @@ export default function OracleStatus({ projectId }: Props) {
       borderRadius: "0.5rem",
       padding: "0.75rem 1rem",
       display: "flex",
-      alignItems: "center",
+      alignItems: "flex-start",
       gap: "0.75rem",
     }}>
-      <span style={{ fontSize: "1.1rem" }}>{isCurrent ? "🛰️" : "⚠️"}</span>
-      <div>
+      <span style={{ fontSize: "1.1rem", marginTop: "0.05rem" }}>{isCurrent ? "🛰️" : "⚠️"}</span>
+      <div style={{ flex: 1 }}>
         <p style={{ fontWeight: 600, fontSize: "0.8rem", color: text, margin: 0 }}>
           {isCurrent ? "Monitoring Current" : "Monitoring Data Stale"}
         </p>
-        {data?.lastSubmittedAt && (
+        {daysSince !== null ? (
           <p style={{ fontSize: "0.7rem", color: text, margin: "0.1rem 0 0", opacity: 0.8 }}>
-            Last update: {new Date(data.lastSubmittedAt).toLocaleDateString()}
-            {data.latestScore !== null && ` · Score: ${data.latestScore}/100`}
+            Last update: {daysSince === 0 ? "today" : `${daysSince} day${daysSince === 1 ? "" : "s"} ago`}
+            {data?.latestScore !== null && ` · Score: ${data.latestScore}/100`}
           </p>
-        )}
-        {!data?.lastSubmittedAt && (
+        ) : (
           <p style={{ fontSize: "0.7rem", color: text, margin: "0.1rem 0 0", opacity: 0.8 }}>
             No monitoring data submitted yet
           </p>
+        )}
+        {isExpiringSoon && daysUntilStale !== null && (
+          <span style={{
+            display: "inline-block",
+            marginTop: "0.35rem",
+            background: "#FEF3C7",
+            color: "#92400E",
+            border: "1px solid #FDE68A",
+            borderRadius: "9999px",
+            padding: "0.1rem 0.5rem",
+            fontSize: "0.65rem",
+            fontWeight: 700,
+          }}>
+            Expires in {daysUntilStale} day{daysUntilStale === 1 ? "" : "s"}
+          </span>
         )}
       </div>
     </div>


### PR DESCRIPTION
- Add Active Credits stat card (issued minus retired)
- Add ProjectStaleAlert component: shows amber banner per project when oracle monitoring data is within 60 days of the 365-day staleness limit
- Add Recent Earnings table: retirements of developer project credits with Stellar Explorer tx links
- Update OracleStatus component to show days since last update and an expiry warning badge when fewer than 60 days remain

Closes #106