### PR TITLE
feat(backend): configure Prisma connection pool for production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,15 @@ ADMIN_PUBLIC_KEY=
 DATABASE_URL=postgresql://carbonledger:changeme@localhost:5432/carbonledger
 POSTGRES_PASSWORD=changeme
 
+# ── Prisma Connection Pool ────────────────────────────────────────────────────
+# Max connections Prisma may open to PostgreSQL (default: 10).
+# Rule of thumb: (num_cores * 2) + 1, capped by pg max_connections / num_replicas.
+DB_POOL_MAX=10
+# Milliseconds to wait for a free connection before throwing P2024 (default: 10000).
+DB_POOL_TIMEOUT_MS=10000
+# Seconds to wait when opening a new TCP connection to PostgreSQL (default: 10).
+DB_CONNECT_TIMEOUT_S=10
+
 # ── Auth ──────────────────────────────────────────────────────────────────────
 JWT_SECRET=change-this-to-a-long-random-secret-in-production
 JWT_EXPIRY=7d

--- a/backend/docs/CONNECTION_POOL.md
+++ b/backend/docs/CONNECTION_POOL.md
@@ -1,0 +1,71 @@
+# Prisma Connection Pool Configuration
+
+## Overview
+
+CarbonLedger uses Prisma's built-in connection pool (via `libquery`) to manage PostgreSQL connections. Unbounded connections exhaust `max_connections` on the database server; this configuration enforces safe limits for production.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `DB_POOL_MAX` | `10` | Maximum open connections per Prisma instance |
+| `DB_POOL_TIMEOUT_MS` | `10000` | Milliseconds to wait for a free slot before throwing `P2024` |
+| `DB_CONNECT_TIMEOUT_S` | `10` | Seconds to wait when opening a new TCP connection |
+
+These are appended to `DATABASE_URL` as query parameters (`connection_limit`, `pool_timeout`, `connect_timeout`) and also passed to the `PrismaClient` constructor so both the URL and the client agree.
+
+## Sizing Guidelines
+
+```
+DB_POOL_MAX = (num_cores × 2) + 1
+```
+
+Cap at: `pg max_connections / number_of_backend_replicas − 5` (leave headroom for migrations and admin tools).
+
+| Deployment | Recommended `DB_POOL_MAX` |
+|---|---|
+| Single replica, 2-core | 5 |
+| Single replica, 4-core | 10 (default) |
+| 3 replicas, 4-core each | 10 (30 total, safe under pg default 100) |
+| High-traffic, dedicated DB | 20–25 |
+
+## Pool Metrics Endpoint
+
+```
+GET /api/v1/health/pool
+```
+
+Response:
+
+```json
+{
+  "pool_max": 10,
+  "pool_timeout_ms": 10000,
+  "connect_timeout_s": 10,
+  "active_queries": 3,
+  "total_queries": 14821,
+  "pool_timeout_errors": 0
+}
+```
+
+`pool_timeout_errors` counts `P2024` errors (pool exhausted). Alert if this is non-zero in production.
+
+## Load Testing
+
+The spec `src/prisma.pool.spec.ts` fires 500 concurrent `SELECT 1` queries and asserts ≤1% failure rate:
+
+```bash
+cd backend
+DATABASE_URL=postgresql://... DB_POOL_MAX=10 npx jest --testPathPattern=prisma.pool
+```
+
+Expected output with `DB_POOL_MAX=10`: all 500 queries succeed (they queue behind the pool and drain within `pool_timeout`).
+
+## Error Handling
+
+Prisma throws `PrismaClientKnownRequestError` with code `P2024` when the pool is exhausted and `pool_timeout` expires. Callers should catch this and return HTTP 503.
+
+## References
+
+- [Prisma connection pool docs](https://www.prisma.io/docs/orm/prisma-client/setup-and-configuration/databases-connections/connection-pool)
+- [PostgreSQL max_connections](https://www.postgresql.org/docs/current/runtime-config-connection.html)

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { Module, Controller, Get } from "@nestjs/common";
 import { BullModule } from "@nestjs/bullmq";
 import { AuthModule } from "./auth/auth.module";
 import { ProjectsModule } from "./projects/projects.module";
@@ -12,6 +12,8 @@ import { PrismaService } from "./prisma.service";
 
 @Controller("health")
 class HealthController {
+  constructor(private readonly prisma: PrismaService) {}
+
   @Get()
   check() {
     return {
@@ -19,6 +21,11 @@ class HealthController {
       stellar_network: process.env.STELLAR_NETWORK || "testnet",
       timestamp: new Date().toISOString(),
     };
+  }
+
+  @Get("pool")
+  pool() {
+    return this.prisma.getPoolMetrics();
   }
 }
 

--- a/backend/src/prisma.pool.spec.ts
+++ b/backend/src/prisma.pool.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Connection pool load test — 500 concurrent queries
+ *
+ * Run: DATABASE_URL=<url> npx ts-node src/prisma.pool.spec.ts
+ * Or via jest: jest --testPathPattern=prisma.pool
+ */
+import { PrismaService } from "./prisma.service";
+
+const CONCURRENCY = 500;
+const TIMEOUT_MS = 30_000;
+
+async function runLoadTest() {
+  process.env.DATABASE_URL =
+    process.env.DATABASE_URL ?? "postgresql://user:password@localhost:5432/carbonledger";
+  process.env.DB_POOL_MAX = process.env.DB_POOL_MAX ?? "10";
+
+  const prisma = new PrismaService();
+  await prisma.onModuleInit();
+
+  const start = Date.now();
+  let succeeded = 0;
+  let failed = 0;
+
+  const tasks = Array.from({ length: CONCURRENCY }, () =>
+    prisma.$queryRaw`SELECT 1 AS n`
+      .then(() => succeeded++)
+      .catch(() => failed++),
+  );
+
+  await Promise.all(tasks);
+
+  const elapsed = Date.now() - start;
+  const metrics = prisma.getPoolMetrics();
+
+  await prisma.onModuleDestroy();
+
+  return { succeeded, failed, elapsed, metrics };
+}
+
+describe("Prisma connection pool — 500 concurrent queries", () => {
+  jest.setTimeout(TIMEOUT_MS);
+
+  it("handles 500 concurrent queries with ≤1% failure rate", async () => {
+    const { succeeded, failed, elapsed, metrics } = await runLoadTest();
+
+    console.log(
+      `Results: ${succeeded} ok / ${failed} failed in ${elapsed}ms | pool_max=${metrics.pool_max}`,
+    );
+
+    const failRate = failed / CONCURRENCY;
+    expect(failRate).toBeLessThanOrEqual(0.01); // ≤1% failures
+    expect(succeeded).toBeGreaterThanOrEqual(CONCURRENCY * 0.99);
+    expect(metrics.pool_max).toBe(parseInt(process.env.DB_POOL_MAX ?? "10"));
+  });
+});

--- a/backend/src/prisma.service.ts
+++ b/backend/src/prisma.service.ts
@@ -1,12 +1,66 @@
-import { Injectable, OnModuleInit, OnModuleDestroy } from "@nestjs/common";
+import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from "@nestjs/common";
 import { PrismaClient } from "@prisma/client";
+
+// Pool sizing: allow override via env, default to 10 for production safety.
+// Formula: (num_cores * 2) + effective_spindle_count — start conservative.
+const POOL_MAX = parseInt(process.env.DB_POOL_MAX ?? "10");
+const POOL_TIMEOUT_MS = parseInt(process.env.DB_POOL_TIMEOUT_MS ?? "10000");
+const CONNECT_TIMEOUT_S = parseInt(process.env.DB_CONNECT_TIMEOUT_S ?? "10");
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(PrismaService.name);
+
+  // Track in-flight query count for pool metrics
+  private _activeQueries = 0;
+  private _totalQueries = 0;
+  private _poolErrors = 0;
+
+  constructor() {
+    const url = new URL(process.env.DATABASE_URL!);
+    url.searchParams.set("connection_limit", String(POOL_MAX));
+    url.searchParams.set("pool_timeout", String(POOL_TIMEOUT_MS / 1000));
+    url.searchParams.set("connect_timeout", String(CONNECT_TIMEOUT_S));
+
+    super({
+      datasources: { db: { url: url.toString() } },
+      log: process.env.NODE_ENV === "development" ? ["query", "warn", "error"] : ["warn", "error"],
+    });
+
+    // Middleware to track active queries for metrics
+    this.$use(async (params, next) => {
+      this._activeQueries++;
+      this._totalQueries++;
+      try {
+        return await next(params);
+      } catch (err: any) {
+        if (err?.code === "P2024") this._poolErrors++; // pool timeout
+        throw err;
+      } finally {
+        this._activeQueries--;
+      }
+    });
+  }
+
   async onModuleInit() {
     await this.$connect();
+    this.logger.log(
+      `Prisma connected — pool_max=${POOL_MAX} pool_timeout=${POOL_TIMEOUT_MS}ms connect_timeout=${CONNECT_TIMEOUT_S}s`,
+    );
   }
+
   async onModuleDestroy() {
     await this.$disconnect();
+  }
+
+  getPoolMetrics() {
+    return {
+      pool_max: POOL_MAX,
+      pool_timeout_ms: POOL_TIMEOUT_MS,
+      connect_timeout_s: CONNECT_TIMEOUT_S,
+      active_queries: this._activeQueries,
+      total_queries: this._totalQueries,
+      pool_timeout_errors: this._poolErrors,
+    };
   }
 }


### PR DESCRIPTION
- Add DB_POOL_MAX, DB_POOL_TIMEOUT_MS, DB_CONNECT_TIMEOUT_S env vars
- Inject pool params into DATABASE_URL and PrismaClient constructor
- Track active_queries, total_queries, pool_timeout_errors via middleware
- Expose GET /api/v1/health/pool metrics endpoint
- Add 500-concurrent load test (prisma.pool.spec.ts)
- Document sizing guidelines in backend/docs/CONNECTION_POOL.md

Closes #36