### PR TITLE
feat: verify cross-contract calls in marketplace cannot be spoofed

### DIFF
--- a/contracts/carbon_marketplace/Cargo.toml
+++ b/contracts/carbon_marketplace/Cargo.toml
@@ -11,6 +11,7 @@ soroban-sdk = { version = "20.0.0", features = ["alloc"] }
 
 [dev-dependencies]
 soroban-sdk = { version = "20.0.0", features = ["testutils", "alloc"] }
+carbon_credit = { path = "../carbon_credit", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/contracts/carbon_marketplace/src/lib.rs
+++ b/contracts/carbon_marketplace/src/lib.rs
@@ -2,7 +2,7 @@
 
 use soroban_sdk::{
     contract, contractimpl, contracttype, contracterror,
-    Address, Env, String, Vec,
+    Address, Env, String, Vec, IntoVal,
     symbol_short, vec,
     token,
 };
@@ -47,6 +47,7 @@ pub enum DataKey {
     AllListings,
     Admin,
     UsdcToken,
+    CreditContract,
     SuspendedProject(String),
 }
 
@@ -85,15 +86,16 @@ pub struct CarbonMarketplaceContract;
 #[contractimpl]
 impl CarbonMarketplaceContract {
 
-    /// Initialise marketplace with admin and USDC token contract address.
+    /// Initialise marketplace with admin, USDC token, and credit contract address.
     /// Can only be called once — subsequent calls return [`CarbonError::AlreadyInitialized`].
-    pub fn initialize(env: Env, admin: Address, usdc_token: Address) -> Result<(), CarbonError> {
+    pub fn initialize(env: Env, admin: Address, usdc_token: Address, credit_contract: Address) -> Result<(), CarbonError> {
         if env.storage().persistent().has(&DataKey::Admin) {
             return Err(CarbonError::AlreadyInitialized);
         }
         admin.require_auth();
         env.storage().persistent().set(&DataKey::Admin, &admin);
         env.storage().persistent().set(&DataKey::UsdcToken, &usdc_token);
+        env.storage().persistent().set(&DataKey::CreditContract, &credit_contract);
         let listings: Vec<String> = vec![&env];
         env.storage().persistent().set(&DataKey::AllListings, &listings);
         Ok(())
@@ -271,6 +273,21 @@ impl CarbonMarketplaceContract {
         let admin: Address = env.storage().persistent().get(&DataKey::Admin).unwrap();
         usdc_client.transfer(&buyer, &admin, &protocol_fee);
 
+        // Transfer credits from seller to buyer via the verified credit contract.
+        // The contract address was set at initialization and cannot be changed.
+        let credit_contract: Address = env.storage().persistent().get(&DataKey::CreditContract).unwrap();
+        env.invoke_contract::<()>(
+            &credit_contract,
+            &soroban_sdk::Symbol::new(&env, "transfer_credits"),
+            soroban_sdk::vec![
+                &env,
+                listing.seller.into_val(&env),
+                buyer.into_val(&env),
+                listing.batch_id.into_val(&env),
+                amount.into_val(&env),
+            ],
+        );
+
         env.events().publish(
             (symbol_short!("c_ledger"), symbol_short!("purchase")),
             (listing_id, buyer, listing.seller, amount, total_cost),
@@ -340,6 +357,19 @@ impl CarbonMarketplaceContract {
 
             let admin: Address = env.storage().persistent().get(&DataKey::Admin).unwrap();
             usdc_client.transfer(&buyer, &admin, &protocol_fee);
+
+            let credit_contract: Address = env.storage().persistent().get(&DataKey::CreditContract).unwrap();
+            env.invoke_contract::<()>(
+                &credit_contract,
+                &soroban_sdk::Symbol::new(&env, "transfer_credits"),
+                soroban_sdk::vec![
+                    &env,
+                    listing.seller.into_val(&env),
+                    buyer.clone().into_val(&env),
+                    listing.batch_id.into_val(&env),
+                    amount.into_val(&env),
+                ],
+            );
 
             env.events().publish(
                 (symbol_short!("c_ledger"), symbol_short!("bulk_buy")),
@@ -418,9 +448,10 @@ impl CarbonMarketplaceContract {
 mod tests {
     use super::*;
     use soroban_sdk::{
-        testutils::{Address as _, MockAuth, MockAuthInvoke},
-        vec, Env, IntoVal, String,
+        testutils::Address as _,
+        vec, Env, String,
     };
+    use carbon_credit::CarbonCreditContract;
 
     fn s(env: &Env, v: &str) -> String { String::from_str(env, v) }
 
@@ -429,9 +460,10 @@ mod tests {
         let admin  = Address::generate(env);
         let seller = Address::generate(env);
         let usdc   = env.register_stellar_asset_contract(admin.clone());
+        let credit_id = env.register_contract(None, CarbonCreditContract);
         let id     = env.register_contract(None, CarbonMarketplaceContract);
         let client = CarbonMarketplaceContractClient::new(env, &id);
-        client.initialize(&admin, &usdc).unwrap();
+        client.initialize(&admin, &usdc, &credit_id).unwrap();
         (client, admin, seller, usdc)
     }
 
@@ -566,5 +598,43 @@ mod tests {
         add_listing(&env, &client, &seller);
         let l = client.get_listing(&s(&env, "list-001")).unwrap();
         assert_eq!(l.status, ListingStatus::Active);
+    }
+
+    /// Deploying the marketplace with a wrong (unrelated) credit contract address
+    /// must cause purchases to fail — the cross-contract call will find no
+    /// `transfer_credits` function and the transaction will be rejected.
+    #[test]
+    fn test_purchase_fails_with_wrong_credit_contract() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin  = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let buyer  = Address::generate(&env);
+        let usdc   = env.register_stellar_asset_contract(admin.clone());
+
+        // Register a dummy contract that has no transfer_credits function.
+        // Using the marketplace contract itself as the "wrong" credit contract.
+        let wrong_credit = env.register_contract(None, CarbonMarketplaceContract);
+
+        let mkt_id = env.register_contract(None, CarbonMarketplaceContract);
+        let client = CarbonMarketplaceContractClient::new(&env, &mkt_id);
+        client.initialize(&admin, &usdc, &wrong_credit).unwrap();
+
+        client.list_credits(
+            &seller,
+            &s(&env, "list-001"),
+            &s(&env, "batch-001"),
+            &s(&env, "proj-001"),
+            &100_i128,
+            &1_i128,
+            &2023_u32,
+            &s(&env, "VCS"),
+            &s(&env, "Brazil"),
+        ).unwrap();
+
+        // Purchase must fail because wrong_credit has no transfer_credits function
+        let result = client.try_purchase_credits(&buyer, &s(&env, "list-001"), &10_i128);
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
Verify cross-contract calls cannot be intercepted or spoofed
  
  The marketplace was performing USDC transfers on purchase but never calling carbon_credit to actually move the
  credits. This meant credit ownership was never updated on-chain, and there was no verified contract address binding
  the two contracts together.
  
  Changes:
  
  - initialize() now accepts a credit_contract: Address parameter, stored under DataKey::CreditContract at init time
  and never changeable after
  - purchase_credits and bulk_purchase both invoke transfer_credits on the stored contract ID after USDC settlement —
  the address comes from storage, never from caller arguments, so it cannot be spoofed
  - Added carbon_credit as a dev-dependency to enable real contract registration in tests
  - Added test_purchase_fails_with_wrong_credit_contract: deploys the marketplace with an unrelated contract as the
  credit address and asserts that purchases fail, proving the cross-contract call is enforced
  
  Security guarantee: the credit contract address is set once at initialization. There is no setter, no dynamic
  resolution at call time, and no way for a caller to redirect the cross-contract call to a malicious contract.

closes #64 