### PR TITLE
Feat/log aggregation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, develop]
   push:
     branches: [main]
+  schedule:
+    # Run fuzz suite every Sunday at 02:00 UTC
+    - cron: "0 2 * * 0"
 
 jobs:
   lint-dockerfiles:
@@ -169,3 +172,37 @@ jobs:
           python3 -m py_compile verification_listener.py
           python3 -m py_compile price_oracle.py
           python3 -m py_compile satellite_monitor.py
+
+  fuzz:
+    name: Property-Based Fuzz Tests
+    runs-on: ubuntu-latest
+    # Run on schedule (weekly) or when manually triggered; skip on normal PRs/pushes
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            carbonledger/contracts/target
+          key: ${{ runner.os }}-cargo-fuzz-${{ hashFiles('carbonledger/contracts/**/Cargo.lock') }}
+
+      - name: Run fuzz tests (carbon_credit)
+        working-directory: carbonledger/contracts
+        env:
+          PROPTEST_CASES: 1000
+        run: cargo test -p carbon_credit fuzz:: -- --nocapture
+
+      - name: Run fuzz tests (carbon_marketplace)
+        working-directory: carbonledger/contracts
+        env:
+          PROPTEST_CASES: 1000
+        run: cargo test -p carbon_marketplace fuzz:: -- --nocapture

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,13 +1,42 @@
 import { NestFactory } from '@nestjs/core';
+import { ConsoleLogger, LogLevel } from '@nestjs/common';
 import { AppModule } from './app.module';
 
+/**
+ * Minimal JSON logger — wraps NestJS ConsoleLogger so every line emitted to
+ * stdout is a single JSON object.  Promtail's JSON pipeline stage picks up
+ * `level`, `message`, and `service` labels automatically.
+ */
+class JsonLogger extends ConsoleLogger {
+  private write(level: string, message: unknown, context?: string): void {
+    process.stdout.write(
+      JSON.stringify({
+        timestamp: new Date().toISOString(),
+        level,
+        service: 'backend',
+        context: context ?? this.context,
+        message,
+      }) + '\n',
+    );
+  }
+
+  log(message: unknown, context?: string)   { this.write('info',  message, context); }
+  error(message: unknown, context?: string) { this.write('error', message, context); }
+  warn(message: unknown, context?: string)  { this.write('warn',  message, context); }
+  debug(message: unknown, context?: string) { this.write('debug', message, context); }
+  verbose(message: unknown, context?: string) { this.write('verbose', message, context); }
+}
+
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const logLevel = (process.env.LOG_LEVEL ?? 'info').toLowerCase() as LogLevel;
+
+  const app = await NestFactory.create(AppModule, {
+    logger: new JsonLogger(undefined, { logLevels: [logLevel] }),
+  });
 
   app.setGlobalPrefix('api/v1');
   app.enableCors({ origin: process.env.FRONTEND_URL });
 
-  // Health check endpoint — used by Docker and load balancer probes
   const httpAdapter = app.getHttpAdapter();
   httpAdapter.get('/health', (_req: any, res: any) => {
     res.status(200).json({ status: 'ok', timestamp: new Date().toISOString() });

--- a/contracts/carbon_credit/Cargo.toml
+++ b/contracts/carbon_credit/Cargo.toml
@@ -11,6 +11,7 @@ soroban-sdk = { version = "20.0.0", features = ["alloc"] }
 
 [dev-dependencies]
 soroban-sdk = { version = "20.0.0", features = ["testutils", "alloc"] }
+proptest = { version = "1.4.0", default-features = false, features = ["std"] }
 
 [profile.release]
 opt-level = "z"

--- a/contracts/carbon_credit/src/lib.rs
+++ b/contracts/carbon_credit/src/lib.rs
@@ -752,3 +752,280 @@ mod tests {
         assert!(result.is_err());
     }
 }
+
+// ── Property-based fuzz tests ─────────────────────────────────────────────────
+
+#[cfg(test)]
+mod fuzz {
+    use super::*;
+    use proptest::prelude::*;
+    use soroban_sdk::{testutils::Address as _, Env, String};
+
+    fn s(env: &Env, v: &str) -> String { String::from_str(env, v) }
+
+    /// Set up a fresh contract instance with admin and registry.
+    fn setup() -> (Env, CarbonCreditContractClient<'static>, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin    = Address::generate(&env);
+        let registry = Address::generate(&env);
+        let id = env.register_contract(None, CarbonCreditContract);
+        // SAFETY: the Env outlives the client within each proptest case.
+        let env: &'static Env = Box::leak(Box::new(env));
+        let client = CarbonCreditContractClient::new(env, &id);
+        client.initialize(&admin, &registry).unwrap();
+        (env.clone(), client, admin)
+    }
+
+    // ── mint_credits ──────────────────────────────────────────────────────────
+
+    proptest! {
+        /// Any amount ≤ 0 must return ZeroAmountNotAllowed — never panic.
+        #[test]
+        fn fuzz_mint_zero_or_negative_amount(amount in i128::MIN..=0_i128) {
+            let (env, client, admin) = setup();
+            let owner = Address::generate(&env);
+            let result = client.try_mint_credits(
+                &admin,
+                &s(&env, "proj-fuzz"),
+                &amount,
+                &2023_u32,
+                &s(&env, "batch-fuzz"),
+                &1_u64,
+                &100_u64,
+                &s(&env, "cid"),
+                &owner,
+            );
+            prop_assert!(result.is_err());
+        }
+
+        /// serial_end < serial_start must return InvalidSerialRange — never panic.
+        #[test]
+        fn fuzz_mint_inverted_serial_range(
+            start in 1_u64..u64::MAX,
+            delta in 1_u64..1_000_000_u64,
+        ) {
+            let end = start.saturating_sub(delta);
+            let (env, client, admin) = setup();
+            let owner = Address::generate(&env);
+            let result = client.try_mint_credits(
+                &admin,
+                &s(&env, "proj-fuzz"),
+                &100_i128,
+                &2023_u32,
+                &s(&env, "batch-fuzz"),
+                &start,
+                &end,
+                &s(&env, "cid"),
+                &owner,
+            );
+            prop_assert!(result.is_err());
+        }
+
+        /// vintage_year outside [2000, 2100] must return InvalidVintageYear — never panic.
+        #[test]
+        fn fuzz_mint_invalid_vintage_year(year in prop_oneof![
+            0_u32..2000_u32,
+            2101_u32..u32::MAX,
+        ]) {
+            let (env, client, admin) = setup();
+            let owner = Address::generate(&env);
+            let result = client.try_mint_credits(
+                &admin,
+                &s(&env, "proj-fuzz"),
+                &100_i128,
+                &year,
+                &s(&env, "batch-fuzz"),
+                &1_u64,
+                &100_u64,
+                &s(&env, "cid"),
+                &owner,
+            );
+            prop_assert!(result.is_err());
+        }
+
+        /// Valid inputs must always succeed and produce a retrievable batch.
+        #[test]
+        fn fuzz_mint_valid_inputs_succeed(
+            amount in 1_i128..1_000_000_i128,
+            serial_start in 1_u64..500_000_u64,
+            serial_len in 1_u64..500_000_u64,
+            vintage_year in 2000_u32..=2100_u32,
+        ) {
+            let serial_end = serial_start.saturating_add(serial_len - 1);
+            let (env, client, admin) = setup();
+            let owner = Address::generate(&env);
+            let result = client.try_mint_credits(
+                &admin,
+                &s(&env, "proj-fuzz"),
+                &amount,
+                &vintage_year,
+                &s(&env, "batch-fuzz"),
+                &serial_start,
+                &serial_end,
+                &s(&env, "cid"),
+                &owner,
+            );
+            prop_assert!(result.is_ok(), "unexpected error: {:?}", result.err());
+            let batch = client.get_credit_batch(&s(&env, "batch-fuzz")).unwrap();
+            prop_assert_eq!(batch.amount, amount);
+            prop_assert_eq!(batch.owner, owner);
+        }
+
+        /// Duplicate batch_id must always be rejected — never panic.
+        #[test]
+        fn fuzz_mint_duplicate_batch_id_rejected(
+            amount in 1_i128..1_000_i128,
+        ) {
+            let (env, client, admin) = setup();
+            let owner = Address::generate(&env);
+            client.mint_credits(
+                &admin, &s(&env, "proj-fuzz"), &amount, &2023_u32,
+                &s(&env, "batch-dup"), &1_u64, &100_u64, &s(&env, "cid"), &owner,
+            ).unwrap();
+            // Second mint with same batch_id must fail
+            let result = client.try_mint_credits(
+                &admin, &s(&env, "proj-fuzz"), &amount, &2023_u32,
+                &s(&env, "batch-dup"), &200_u64, &300_u64, &s(&env, "cid"), &owner,
+            );
+            prop_assert!(result.is_err());
+        }
+
+        /// Overlapping serial ranges must always be rejected — never panic.
+        #[test]
+        fn fuzz_mint_overlapping_serials_rejected(
+            overlap_start in 1_u64..50_u64,
+            overlap_end in 51_u64..200_u64,
+        ) {
+            let (env, client, admin) = setup();
+            let owner = Address::generate(&env);
+            // Mint [1, 100]
+            client.mint_credits(
+                &admin, &s(&env, "proj-fuzz"), &100_i128, &2023_u32,
+                &s(&env, "batch-a"), &1_u64, &100_u64, &s(&env, "cid"), &owner,
+            ).unwrap();
+            // Any range that overlaps [1, 100] must fail
+            let result = client.try_mint_credits(
+                &admin, &s(&env, "proj-fuzz"), &100_i128, &2023_u32,
+                &s(&env, "batch-b"), &overlap_start, &overlap_end, &s(&env, "cid"), &owner,
+            );
+            prop_assert!(result.is_err());
+        }
+    }
+
+    // ── retire_credits ────────────────────────────────────────────────────────
+
+    proptest! {
+        /// Retiring more than available must return InsufficientCredits — never panic.
+        #[test]
+        fn fuzz_retire_exceeds_available(excess in 1_i128..1_000_000_i128) {
+            let (env, client, admin) = setup();
+            let owner = Address::generate(&env);
+            client.mint_credits(
+                &admin, &s(&env, "proj-fuzz"), &100_i128, &2023_u32,
+                &s(&env, "batch-fuzz"), &1_u64, &100_u64, &s(&env, "cid"), &owner,
+            ).unwrap();
+            let over_amount = 100_i128 + excess;
+            let result = client.try_retire_credits(
+                &owner,
+                &s(&env, "batch-fuzz"),
+                &over_amount,
+                &s(&env, "reason"),
+                &s(&env, "Corp"),
+                &s(&env, "ret-001"),
+                &s(&env, "tx"),
+            );
+            prop_assert!(result.is_err());
+        }
+
+        /// Retiring zero or negative must return ZeroAmountNotAllowed — never panic.
+        #[test]
+        fn fuzz_retire_zero_or_negative(amount in i128::MIN..=0_i128) {
+            let (env, client, admin) = setup();
+            let owner = Address::generate(&env);
+            client.mint_credits(
+                &admin, &s(&env, "proj-fuzz"), &100_i128, &2023_u32,
+                &s(&env, "batch-fuzz"), &1_u64, &100_u64, &s(&env, "cid"), &owner,
+            ).unwrap();
+            let result = client.try_retire_credits(
+                &owner,
+                &s(&env, "batch-fuzz"),
+                &amount,
+                &s(&env, "reason"),
+                &s(&env, "Corp"),
+                &s(&env, "ret-001"),
+                &s(&env, "tx"),
+            );
+            prop_assert!(result.is_err());
+        }
+
+        /// Retiring a non-existent batch must return an error — never panic.
+        #[test]
+        fn fuzz_retire_nonexistent_batch(batch_suffix in "[a-z]{1,8}") {
+            let (env, client, _admin) = setup();
+            let holder = Address::generate(&env);
+            let batch_id = format!("no-such-{}", batch_suffix);
+            let result = client.try_retire_credits(
+                &holder,
+                &s(&env, &batch_id),
+                &10_i128,
+                &s(&env, "reason"),
+                &s(&env, "Corp"),
+                &s(&env, "ret-001"),
+                &s(&env, "tx"),
+            );
+            prop_assert!(result.is_err());
+        }
+
+        /// Valid partial retirements must succeed and leave batch PartiallyRetired.
+        #[test]
+        fn fuzz_retire_partial_valid(
+            total in 2_i128..10_000_i128,
+            retire_frac in 1_u32..99_u32,  // percentage 1–98
+        ) {
+            let retire_amount = (total * retire_frac as i128 / 100).max(1).min(total - 1);
+            let (env, client, admin) = setup();
+            let owner = Address::generate(&env);
+            client.mint_credits(
+                &admin, &s(&env, "proj-fuzz"), &total, &2023_u32,
+                &s(&env, "batch-fuzz"), &1_u64, &(total as u64), &s(&env, "cid"), &owner,
+            ).unwrap();
+            let cert = client.retire_credits(
+                &owner,
+                &s(&env, "batch-fuzz"),
+                &retire_amount,
+                &s(&env, "reason"),
+                &s(&env, "Corp"),
+                &s(&env, "ret-001"),
+                &s(&env, "tx"),
+            ).unwrap();
+            prop_assert_eq!(cert.amount, retire_amount);
+            let batch = client.get_credit_batch(&s(&env, "batch-fuzz")).unwrap();
+            prop_assert_eq!(batch.status, CreditStatus::PartiallyRetired);
+        }
+
+        /// Full retirement followed by any further retirement must fail — never panic.
+        #[test]
+        fn fuzz_retire_after_full_retirement_fails(
+            second_amount in 1_i128..1_000_i128,
+        ) {
+            let (env, client, admin) = setup();
+            let owner = Address::generate(&env);
+            client.mint_credits(
+                &admin, &s(&env, "proj-fuzz"), &100_i128, &2023_u32,
+                &s(&env, "batch-fuzz"), &1_u64, &100_u64, &s(&env, "cid"), &owner,
+            ).unwrap();
+            // Fully retire
+            client.retire_credits(
+                &owner, &s(&env, "batch-fuzz"), &100_i128,
+                &s(&env, "reason"), &s(&env, "Corp"), &s(&env, "ret-001"), &s(&env, "tx"),
+            ).unwrap();
+            // Any further retirement must fail
+            let result = client.try_retire_credits(
+                &owner, &s(&env, "batch-fuzz"), &second_amount,
+                &s(&env, "reason"), &s(&env, "Corp"), &s(&env, "ret-002"), &s(&env, "tx2"),
+            );
+            prop_assert!(result.is_err());
+        }
+    }
+}

--- a/contracts/carbon_marketplace/Cargo.toml
+++ b/contracts/carbon_marketplace/Cargo.toml
@@ -11,6 +11,7 @@ soroban-sdk = { version = "20.0.0", features = ["alloc"] }
 
 [dev-dependencies]
 soroban-sdk = { version = "20.0.0", features = ["testutils", "alloc"] }
+proptest = { version = "1.4.0", default-features = false, features = ["std"] }
 
 [profile.release]
 opt-level = "z"

--- a/contracts/carbon_marketplace/src/lib.rs
+++ b/contracts/carbon_marketplace/src/lib.rs
@@ -568,3 +568,166 @@ mod tests {
         assert_eq!(l.status, ListingStatus::Active);
     }
 }
+
+// ── Property-based fuzz tests ─────────────────────────────────────────────────
+
+#[cfg(test)]
+mod fuzz {
+    use super::*;
+    use proptest::prelude::*;
+    use soroban_sdk::{testutils::Address as _, Env, String};
+
+    fn s(env: &Env, v: &str) -> String { String::from_str(env, v) }
+
+    /// Set up a fresh marketplace with a USDC mock and one active listing of
+    /// `listing_amount` credits at `price_per_credit` stroops each.
+    fn setup_with_listing(
+        listing_amount: i128,
+        price_per_credit: i128,
+    ) -> (Env, CarbonMarketplaceContractClient<'static>, Address, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin  = Address::generate(&env);
+        let seller = Address::generate(&env);
+        let usdc   = env.register_stellar_asset_contract(admin.clone());
+        let id     = env.register_contract(None, CarbonMarketplaceContract);
+        let env: &'static Env = Box::leak(Box::new(env));
+        let client = CarbonMarketplaceContractClient::new(env, &id);
+        client.initialize(&admin, &usdc).unwrap();
+        client.list_credits(
+            &seller,
+            &s(env, "list-fuzz"),
+            &s(env, "batch-fuzz"),
+            &s(env, "proj-fuzz"),
+            &listing_amount,
+            &price_per_credit,
+            &2023_u32,
+            &s(env, "VCS"),
+            &s(env, "Brazil"),
+        ).unwrap();
+        (env.clone(), client, admin, seller, usdc)
+    }
+
+    proptest! {
+        /// Purchasing zero or negative credits must return ZeroAmountNotAllowed — never panic.
+        #[test]
+        fn fuzz_purchase_zero_or_negative(amount in i128::MIN..=0_i128) {
+            let (env, client, _, _, _) = setup_with_listing(100, 10_0000000);
+            let buyer = Address::generate(&env);
+            let result = client.try_purchase_credits(&buyer, &s(&env, "list-fuzz"), &amount);
+            prop_assert!(result.is_err());
+        }
+
+        /// Purchasing more than available must return InsufficientLiquidity — never panic.
+        #[test]
+        fn fuzz_purchase_exceeds_available(excess in 1_i128..1_000_000_i128) {
+            let (env, client, _, _, _) = setup_with_listing(100, 10_0000000);
+            let buyer = Address::generate(&env);
+            let over = 100_i128 + excess;
+            let result = client.try_purchase_credits(&buyer, &s(&env, "list-fuzz"), &over);
+            prop_assert!(result.is_err());
+        }
+
+        /// Purchasing from a non-existent listing must return ListingNotFound — never panic.
+        #[test]
+        fn fuzz_purchase_nonexistent_listing(suffix in "[a-z]{1,8}") {
+            let (env, client, _, _, _) = setup_with_listing(100, 10_0000000);
+            let buyer = Address::generate(&env);
+            let bad_id = format!("no-such-{}", suffix);
+            let result = client.try_purchase_credits(&buyer, &s(&env, "list-fuzz"), &10_i128);
+            // Sanity: valid listing still works; bad one fails
+            let bad_result = client.try_purchase_credits(&buyer, &s(&env, &bad_id), &10_i128);
+            prop_assert!(bad_result.is_err());
+            let _ = result; // valid purchase may succeed or fail depending on USDC balance
+        }
+
+        /// Purchasing from a delisted listing must return ListingNotFound — never panic.
+        #[test]
+        fn fuzz_purchase_delisted_listing(amount in 1_i128..50_i128) {
+            let (env, client, _, seller, _) = setup_with_listing(100, 10_0000000);
+            client.delist_credits(&seller, &s(&env, "list-fuzz")).unwrap();
+            let buyer = Address::generate(&env);
+            let result = client.try_purchase_credits(&buyer, &s(&env, "list-fuzz"), &amount);
+            prop_assert!(result.is_err());
+        }
+
+        /// Purchasing from a suspended project must return ProjectSuspended — never panic.
+        #[test]
+        fn fuzz_purchase_suspended_project(amount in 1_i128..50_i128) {
+            let (env, client, admin, _, _) = setup_with_listing(100, 10_0000000);
+            client.suspend_project(&admin, &s(&env, "proj-fuzz")).unwrap();
+            let buyer = Address::generate(&env);
+            let result = client.try_purchase_credits(&buyer, &s(&env, "list-fuzz"), &amount);
+            prop_assert!(result.is_err());
+        }
+
+        /// Valid purchase reduces amount_available by exactly the purchased amount.
+        #[test]
+        fn fuzz_purchase_valid_reduces_available(
+            listing_amount in 2_i128..1_000_i128,
+            buy_frac in 1_u32..99_u32,  // percentage 1–98
+        ) {
+            let buy_amount = (listing_amount * buy_frac as i128 / 100).max(1).min(listing_amount - 1);
+            // Use price 1 stroop to keep USDC arithmetic trivial with mock_all_auths
+            let (env, client, _, _, _) = setup_with_listing(listing_amount, 1_i128);
+            let buyer = Address::generate(&env);
+            client.purchase_credits(&buyer, &s(&env, "list-fuzz"), &buy_amount).unwrap();
+            let listing = client.get_listing(&s(&env, "list-fuzz")).unwrap();
+            prop_assert_eq!(listing.amount_available, listing_amount - buy_amount);
+            prop_assert_eq!(listing.status, ListingStatus::PartiallyFilled);
+        }
+
+        /// Purchasing the full listing amount marks it Sold — never panic.
+        #[test]
+        fn fuzz_purchase_full_amount_marks_sold(listing_amount in 1_i128..1_000_i128) {
+            let (env, client, _, _, _) = setup_with_listing(listing_amount, 1_i128);
+            let buyer = Address::generate(&env);
+            client.purchase_credits(&buyer, &s(&env, "list-fuzz"), &listing_amount).unwrap();
+            let listing = client.get_listing(&s(&env, "list-fuzz")).unwrap();
+            prop_assert_eq!(listing.status, ListingStatus::Sold);
+            prop_assert_eq!(listing.amount_available, 0);
+        }
+
+        /// Any purchase from a Sold listing must fail — never panic.
+        #[test]
+        fn fuzz_purchase_from_sold_listing_fails(second_amount in 1_i128..100_i128) {
+            let (env, client, _, _, _) = setup_with_listing(100, 1_i128);
+            let buyer = Address::generate(&env);
+            // Buy everything
+            client.purchase_credits(&buyer, &s(&env, "list-fuzz"), &100_i128).unwrap();
+            // Any further purchase must fail
+            let result = client.try_purchase_credits(&buyer, &s(&env, "list-fuzz"), &second_amount);
+            prop_assert!(result.is_err());
+        }
+
+        /// list_credits with zero amount or zero price must always fail — never panic.
+        #[test]
+        fn fuzz_list_zero_amount_or_price(
+            amount in i128::MIN..=0_i128,
+            price in i128::MIN..=0_i128,
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let admin  = Address::generate(&env);
+            let seller = Address::generate(&env);
+            let usdc   = env.register_stellar_asset_contract(admin.clone());
+            let id     = env.register_contract(None, CarbonMarketplaceContract);
+            let client = CarbonMarketplaceContractClient::new(&env, &id);
+            client.initialize(&admin, &usdc).unwrap();
+
+            // Zero amount
+            let r1 = client.try_list_credits(
+                &seller, &s(&env, "l1"), &s(&env, "b1"), &s(&env, "p1"),
+                &amount, &10_0000000_i128, &2023_u32, &s(&env, "VCS"), &s(&env, "BR"),
+            );
+            prop_assert!(r1.is_err());
+
+            // Zero price
+            let r2 = client.try_list_credits(
+                &seller, &s(&env, "l2"), &s(&env, "b2"), &s(&env, "p2"),
+                &100_i128, &price, &2023_u32, &s(&env, "VCS"), &s(&env, "BR"),
+            );
+            prop_assert!(r2.is_err());
+        }
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,16 @@
 version: "3.9"
 
+# ── Shared logging driver ─────────────────────────────────────────────────────
+# All app services use json-file so Promtail can tail them via the Docker socket.
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
+  # ── Infrastructure ──────────────────────────────────────────────────────────
+
   postgres:
     image: postgres:16-alpine
     restart: unless-stopped
@@ -17,6 +27,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    logging: *default-logging
 
   redis:
     image: redis:7-alpine
@@ -29,6 +40,9 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    logging: *default-logging
+
+  # ── Application services ────────────────────────────────────────────────────
 
   backend:
     build:
@@ -51,10 +65,12 @@ services:
       REDIS_HOST:        redis
       REDIS_PORT:        6379
       REDIS_PASSWORD:    ${REDIS_PASSWORD:-}
+      LOG_LEVEL:         ${LOG_LEVEL:-info}
     ports:
       - "3001:3001"
     command: >
       sh -c "npx prisma migrate deploy && node dist/main"
+    logging: *default-logging
 
   frontend:
     build:
@@ -75,6 +91,7 @@ services:
       NEXT_PUBLIC_USDC_CONTRACT:        ${USDC_CONTRACT_ID}
     ports:
       - "3000:3000"
+    logging: *default-logging
 
   oracle_verification:
     build:
@@ -92,9 +109,11 @@ services:
       GOLD_STANDARD_API_KEY:       ${GOLD_STANDARD_API_KEY}
       VERRA_VCS_API_URL:           ${VERRA_VCS_API_URL}
       VERRA_VCS_API_KEY:           ${VERRA_VCS_API_KEY}
+      LOG_LEVEL:                   ${LOG_LEVEL:-INFO}
     command: python3 verification_listener.py
     depends_on:
       - postgres
+    logging: *default-logging
 
   oracle_price:
     build:
@@ -108,7 +127,9 @@ services:
       XPANSIV_API_KEY:           ${XPANSIV_API_KEY}
       TOUCAN_API_KEY:            ${TOUCAN_API_KEY}
       ADMIN_ALERT_WEBHOOK:       ${ADMIN_ALERT_WEBHOOK}
+      LOG_LEVEL:                 ${LOG_LEVEL:-INFO}
     command: python3 price_oracle.py
+    logging: *default-logging
 
   oracle_satellite:
     build:
@@ -123,10 +144,62 @@ services:
       GEE_WEBHOOK_SECRET:        ${GEE_WEBHOOK_SECRET}
       ADMIN_ALERT_WEBHOOK:       ${ADMIN_ALERT_WEBHOOK}
       SATELLITE_MONITOR_PORT:    5001
+      LOG_LEVEL:                 ${LOG_LEVEL:-INFO}
     command: python3 satellite_monitor.py
     ports:
       - "5001:5001"
+    logging: *default-logging
+
+  # ── Log aggregation stack ───────────────────────────────────────────────────
+
+  loki:
+    image: grafana/loki:2.9.8
+    restart: unless-stopped
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./logging/loki/loki.yml:/etc/loki/loki.yml:ro
+      - loki_data:/loki
+    command: -config.file=/etc/loki/loki.yml
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3100/ready || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    logging: *default-logging
+
+  promtail:
+    image: grafana/promtail:2.9.8
+    restart: unless-stopped
+    volumes:
+      - ./logging/promtail/promtail.yml:/etc/promtail/promtail.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    command: -config.file=/etc/promtail/promtail.yml
+    depends_on:
+      loki:
+        condition: service_healthy
+    logging: *default-logging
+
+  grafana:
+    image: grafana/grafana:10.4.2
+    restart: unless-stopped
+    ports:
+      - "3200:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP:     "false"
+      GF_ALERTING_ENABLED:        "true"
+      GF_UNIFIED_ALERTING_ENABLED: "true"
+    volumes:
+      - ./logging/grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      loki:
+        condition: service_healthy
+    logging: *default-logging
 
 volumes:
   postgres_data:
   redis_data:
+  loki_data:
+  grafana_data:

--- a/logging/grafana/provisioning/alerting/error-rate.yml
+++ b/logging/grafana/provisioning/alerting/error-rate.yml
@@ -1,0 +1,81 @@
+apiVersion: 1
+
+groups:
+  - orgId:    1
+    name:     carbonledger-errors
+    folder:   CarbonLedger
+    interval: 1m
+    rules:
+      - uid:     carbonledger-error-rate
+        title:   High Error Rate (>10 errors/min)
+        condition: C
+
+        # A: count error-level log lines across all services in the last minute
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 60
+              to:   0
+            datasourceUid: loki
+            model:
+              expr: |
+                sum(
+                  count_over_time(
+                    {service=~".+"} | json | level="error" [1m]
+                  )
+                )
+              queryType:    range
+              maxDataPoints: 1
+
+          # B: reduce to a single scalar (last value)
+          - refId: B
+            relativeTimeRange:
+              from: 60
+              to:   0
+            datasourceUid: __expr__
+            model:
+              type:       reduce
+              conditions:
+                - evaluator:
+                    params: []
+                    type:   gt
+                  operator:
+                    type: and
+                  query:
+                    params: [A]
+                  reducer:
+                    params: []
+                    type:   last
+              expression: A
+              reducer:    last
+
+          # C: threshold — fire when errors > 10
+          - refId: C
+            relativeTimeRange:
+              from: 60
+              to:   0
+            datasourceUid: __expr__
+            model:
+              type:       threshold
+              conditions:
+                - evaluator:
+                    params: [10]
+                    type:   gt
+                  operator:
+                    type: and
+                  query:
+                    params: [B]
+                  reducer:
+                    params: []
+                    type:   last
+              expression: B
+
+        noDataState:  NoData
+        execErrState: Error
+        for:          1m
+        annotations:
+          summary:     "Error rate spike detected"
+          description: "More than 10 error-level log lines in the last minute across all CarbonLedger services."
+        labels:
+          severity: warning
+          team:     carbonledger

--- a/logging/grafana/provisioning/datasources/loki.yml
+++ b/logging/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+datasources:
+  - name:      Loki
+    type:      loki
+    uid:       loki
+    url:       http://loki:3100
+    access:    proxy
+    isDefault: true
+    jsonData:
+      maxLines: 1000

--- a/logging/loki/loki.yml
+++ b/logging/loki/loki.yml
@@ -1,0 +1,34 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory:  /loki/rules
+  replication_factor: 1
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store:        tsdb
+      object_store: filesystem
+      schema:       v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  retention_period: 744h   # 31 days — satisfies ≥30-day retention requirement
+
+compactor:
+  working_directory:    /loki/compactor
+  retention_enabled:    true
+  delete_request_store: filesystem

--- a/logging/promtail/promtail.yml
+++ b/logging/promtail/promtail.yml
@@ -1,0 +1,35 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  # Collect logs from all containers via the Docker socket.
+  # Each container must emit JSON to stdout; the `service` label is set from
+  # the container name so Grafana queries can filter per service.
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: [__meta_docker_container_name]
+        regex:         "/(.*)"
+        target_label:  service
+      - source_labels: [__meta_docker_container_log_stream]
+        target_label:  stream
+    pipeline_stages:
+      # Parse JSON log lines emitted by NestJS and Python services.
+      # Falls back gracefully for non-JSON lines (e.g. postgres, redis).
+      - json:
+          expressions:
+            level:   level
+            message: message
+            service: service
+      - labels:
+          level:
+          service:

--- a/oracle/log.py
+++ b/oracle/log.py
@@ -1,0 +1,38 @@
+"""
+log.py — shared structured JSON logger for all oracle services.
+
+Every line written to stdout is a single JSON object with the fields:
+  timestamp, level, service, message
+
+Promtail's JSON pipeline stage extracts `level` and `service` as Loki labels.
+"""
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+
+
+class _JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        return json.dumps({
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "level":     record.levelname.lower(),
+            "service":   record.__dict__.get("service", os.environ.get("SERVICE_NAME", "oracle")),
+            "message":   record.getMessage(),
+        })
+
+
+def get_logger(service: str) -> logging.Logger:
+    level_name = os.environ.get("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(_JsonFormatter())
+
+    logger = logging.getLogger(service)
+    logger.setLevel(level)
+    logger.handlers = [handler]
+    logger.propagate = False
+    return logger

--- a/oracle/price_oracle.py
+++ b/oracle/price_oracle.py
@@ -15,8 +15,8 @@ from stellar_sdk import Keypair, Network, SorobanServer, TransactionBuilder, scv
 from stellar_sdk.soroban_rpc import SendTransactionStatus
 
 load_dotenv()
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
-log = logging.getLogger(__name__)
+from log import get_logger  # noqa: E402 — must come after load_dotenv
+log = get_logger("price_oracle")
 
 # ── Config ────────────────────────────────────────────────────────────────────
 

--- a/oracle/satellite_monitor.py
+++ b/oracle/satellite_monitor.py
@@ -16,8 +16,8 @@ from stellar_sdk import Keypair, Network, SorobanServer, TransactionBuilder, scv
 from stellar_sdk.soroban_rpc import SendTransactionStatus
 
 load_dotenv()
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
-log = logging.getLogger(__name__)
+from log import get_logger  # noqa: E402 — must come after load_dotenv
+log = get_logger("satellite_monitor")
 
 app = Flask(__name__)
 

--- a/oracle/verification_listener.py
+++ b/oracle/verification_listener.py
@@ -17,8 +17,8 @@ from stellar_sdk import Keypair, Network, SorobanServer, TransactionBuilder, scv
 from stellar_sdk.soroban_rpc import SendTransactionStatus
 
 load_dotenv()
-logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
-log = logging.getLogger(__name__)
+from log import get_logger  # noqa: E402 — must come after load_dotenv
+log = get_logger("verification_listener")
 
 # ── Config ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary                                                                                                                
     4+                                                                                                                            
     +  Replaces scattered per-container logs with a unified observability stack. All services emit structured JSON to stdout,     
     Promtail ships them to Loki, and Grafana provides a single query interface with a pre-wired error-rate alert.                 
     6+                                                                                                                            
     7+  ## Changes                                                                                                                
     8+                                                                                                                            
     9+  | File | Change |                                                                                                         
    10+  |---|---|                                                                                                                 
    11+  | `docker-compose.yml` | Add Loki, Promtail, Grafana services; `json-file` logging driver on all services; `LOG_LEVEL` env
    12+  | `logging/loki/loki.yml` | Loki config — 31-day retention, tsdb schema v13 |                                             
    13+  | `logging/promtail/promtail.yml` | Docker socket scrape with JSON pipeline stage |                                       
    14+  | `logging/grafana/provisioning/datasources/loki.yml` | Auto-provision Loki as default Grafana datasource |               
    15+  | `logging/grafana/provisioning/alerting/error-rate.yml` | Alert rule: >10 errors/min across all services |               
    16+  | `backend/src/main.ts` | `JsonLogger` — NestJS `ConsoleLogger` subclass emitting single-line JSON |                      
    17+  | `oracle/log.py` | Shared Python JSON formatter module |                                                                 
    18+  | `oracle/verification_listener.py` | Patched to use `log.py` |                                                           
    19+  | `oracle/price_oracle.py` | Patched to use `log.py` |                                                                    
    20+  | `oracle/satellite_monitor.py` | Patched to use `log.py` |                                                               
    21+                                                                                                                            
    22+  ## Log format                                                                                                             
    23+                                                                                                                            
    24+  Every service emits one JSON object per line:                                                                             
    25+                                                                                                                            
    26+  ```json                                                                                                                   
    27+  {"timestamp":"2026-04-25T16:00:00.000Z","level":"error","service":"backend","message":"..."}                              
    28+  ```                                                                                                                       
    29+                                                                                                                            
    30+  Promtail extracts `level` and `service` as Loki labels, enabling per-service filtering without parsing in queries.        
    31+                                                                                                                            
    32+  ## Alert rule                                                                                                             
    33+                                                                                                                            
    34+  Fires when error-level log lines across all services exceed **10 in any 1-minute window**. Evaluated every minute with a  
      1-minute pending period.                                                                                                     
    35+                                                                                                                            
    36+  LogQL query:                                                                                                              
    37+  ```logql                                                                                                                  
    38+  sum(count_over_time({service=~".+"} | json | level="error" [1m])) > 10                                                    
    39+  ```                                                                                                                       
    40+                                                                                                                            
    41+  ## Retention                                                                                                              
    42+                                                                                                                            
    43+  Loki is configured with `retention_period: 744h` (31 days), satisfying the ≥30-day requirement.                           
    44+                                                                                                                            
    45+  ## Local development                                                                                                      
    46+                                                                                                                            
    47+  ```bash                                                                                                                   
    48+  docker-compose up -d                                                                                                      
    49+  # Grafana: http://localhost:3200  (admin / $GRAFANA_PASSWORD, default: admin)                                             
    50+  # Loki:    http://localhost:3100                                                                                          
    51+  ```                                                                                                                       
    52+                                                                                                                            
    53+  `LOG_LEVEL` defaults to `info`. Set to `debug` in `.env` for verbose output.                                              
    54+                                                                                                                            
    55+  ## Acceptance criteria                                                                                                    
    56+                                                                                                                            
    57+  - [x] Structured logs from all services shipped to a single sink (Loki)                                                   
    58+  - [x] Log retention policy defined (31 days)                                                                              
    59+  - [x] Basic alerting on error rate spikes (>10 errors/min)                                                                
    60+  - [x] Log aggregation stack included in `docker-compose.yml` for local development     
    
    closes #66