### PR TITLE
chore(security): secrets management — pre-commit hook, clean .env.example (#69)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,11 +20,11 @@ ADMIN_SECRET_KEY=
 ADMIN_PUBLIC_KEY=
 
 # ── Database ──────────────────────────────────────────────────────────────────
-DATABASE_URL=postgresql://carbonledger:changeme@localhost:5432/carbonledger
-POSTGRES_PASSWORD=changeme
+DATABASE_URL=postgresql://carbonledger:<POSTGRES_PASSWORD>@localhost:5432/carbonledger
+POSTGRES_PASSWORD=
 
 # ── Auth ──────────────────────────────────────────────────────────────────────
-JWT_SECRET=change-this-to-a-long-random-secret-in-production
+JWT_SECRET=
 JWT_EXPIRY=7d
 
 # ── IPFS / Pinata ─────────────────────────────────────────────────────────────

--- a/docs/secrets-management.md
+++ b/docs/secrets-management.md
@@ -1,0 +1,54 @@
+# Secrets Management
+
+## Rules
+
+1. **Never commit real secret values.** `.env` is in `.gitignore`. `.env.example` contains only empty placeholders.
+2. **Pre-commit hook** blocks commits containing secret patterns. Install it:
+   ```bash
+   bash scripts/setup-hooks.sh
+   ```
+
+## Local Development
+
+```bash
+cp .env.example .env
+# Fill in values — this file is gitignored and never committed
+```
+
+## Production Secrets — AWS Secrets Manager
+
+All production secrets are stored in AWS Secrets Manager under the path `carbonledger/<env>/<key>`.
+
+| Secret Name | AWS Path |
+|---|---|
+| `ORACLE_SECRET_KEY` | `carbonledger/prod/oracle-secret-key` |
+| `ADMIN_SECRET_KEY` | `carbonledger/prod/admin-secret-key` |
+| `JWT_SECRET` | `carbonledger/prod/jwt-secret` |
+| `DATABASE_URL` | `carbonledger/prod/database-url` |
+| `IPFS_SECRET_KEY` | `carbonledger/prod/ipfs-secret-key` |
+
+Retrieve at runtime:
+```bash
+aws secretsmanager get-secret-value \
+  --secret-id carbonledger/prod/oracle-secret-key \
+  --query SecretString --output text
+```
+
+The ECS task role has `secretsmanager:GetSecretValue` scoped to `carbonledger/*`.
+
+## CI — GitHub Actions Secrets
+
+Secrets are injected via GitHub Actions repository secrets (Settings → Secrets and variables → Actions).
+
+Required secrets:
+
+| Secret | Used by |
+|---|---|
+| `DATABASE_URL` | backend CI, staging deploy |
+| `JWT_SECRET` | backend CI |
+| `STELLAR_ORACLE_SECRET_KEY` | contract-redeploy workflow |
+| `STELLAR_ADMIN_SECRET_KEY` | contract-redeploy workflow |
+| `AWS_ACCESS_KEY_ID` | staging/prod deploy |
+| `AWS_SECRET_ACCESS_KEY` | staging/prod deploy |
+
+These are referenced in workflows as `${{ secrets.SECRET_NAME }}` and are never printed in logs.

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Pre-commit hook: block accidental secret commits
+# Checks staged files for patterns that look like real secrets
+#
+# Install: cp scripts/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+# Or run:  bash scripts/setup-hooks.sh
+
+set -euo pipefail
+
+RED='\033[0;31m'
+NC='\033[0m'
+
+STAGED=$(git diff --cached --name-only --diff-filter=ACM)
+
+if [ -z "$STAGED" ]; then
+  exit 0
+fi
+
+# Block .env files (except .env.example)
+for f in $STAGED; do
+  if [[ "$f" =~ ^\.env$ ]] || ([[ "$f" =~ \.env\. ]] && [[ ! "$f" =~ \.env\.example ]]); then
+    echo -e "${RED}ERROR: Attempting to commit env file: $f${NC}"
+    echo "Remove it with: git reset HEAD $f"
+    exit 1
+  fi
+done
+
+# Patterns that indicate real secret values
+SECRET_PATTERNS=(
+  'ORACLE_SECRET_KEY=[A-Z0-9]{56}'
+  'ADMIN_SECRET_KEY=[A-Z0-9]{56}'
+  'JWT_SECRET=[^$\n]{20,}'
+  'POSTGRES_PASSWORD=[^$\n<]{4,}'
+  'IPFS_SECRET_KEY=[^$\n]{10,}'
+  'PLANET_LABS_API_KEY=[^$\n]{10,}'
+  'GOOGLE_EARTH_ENGINE_KEY=[^$\n]{10,}'
+  'XPANSIV_API_KEY=[^$\n]{10,}'
+  'TOUCAN_API_KEY=[^$\n]{10,}'
+  'GEE_WEBHOOK_SECRET=[^$\n]{10,}'
+  'GOLD_STANDARD_API_KEY=[^$\n]{10,}'
+  'VERRA_VCS_API_KEY=[^$\n]{10,}'
+  'ADMIN_ALERT_WEBHOOK=https?://[^$\n]{10,}'
+  'S[A-Z0-9]{55}'
+  'AAAA[A-Za-z0-9+/]{60,}={0,2}'
+)
+
+FOUND=0
+for f in $STAGED; do
+  for pattern in "${SECRET_PATTERNS[@]}"; do
+    if git diff --cached -- "$f" | grep -qE "^\+.*${pattern}"; then
+      echo -e "${RED}ERROR: Possible secret detected in $f (pattern: $pattern)${NC}"
+      FOUND=1
+    fi
+  done
+done
+
+if [ "$FOUND" -eq 1 ]; then
+  echo ""
+  echo "Commit blocked. Review the above and:"
+  echo "  1. Remove the secret value from the file"
+  echo "  2. Store it in AWS Secrets Manager or GitHub Actions secrets"
+  echo "  3. Reference it via environment variable injection at runtime"
+  echo ""
+  echo "To bypass (only if you are certain this is a false positive):"
+  echo "  git commit --no-verify"
+  exit 1
+fi
+
+exit 0

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Install git hooks from scripts/ into .git/hooks/
+set -euo pipefail
+cp scripts/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+echo "Git hooks installed."


### PR DESCRIPTION
Closes #69

## Changes

### `.env.example`
- Removed placeholder values that could be mistaken for real secrets:
  - `JWT_SECRET` → empty (was `change-this-to-a-long-random-secret-in-production`)
  - `POSTGRES_PASSWORD` → empty (was `changeme`)
  - `DATABASE_URL` → uses `<POSTGRES_PASSWORD>` template token instead of literal value

### `scripts/pre-commit` (tracked hook)
Blocks commits that contain:
- Stellar secret keys (`S[A-Z0-9]{55}`)
- `ORACLE_SECRET_KEY`, `ADMIN_SECRET_KEY` with real values
- `JWT_SECRET`, `POSTGRES_PASSWORD`, API keys with non-empty values
- `.env` files (except `.env.example`)

Install with: `bash scripts/setup-hooks.sh`

### `docs/secrets-management.md`
Documents:
- AWS Secrets Manager paths for all production secrets
- GitHub Actions secrets required for CI
- Local dev workflow

## Acceptance Criteria
- [x] `.env` in `.gitignore` (verified — already present)
- [x] `.env.example` contains no real values
- [x] Production secrets stored in AWS Secrets Manager (documented)
- [x] CI secrets injected via GitHub Actions secrets (documented)
- [x] Pre-commit hook blocks accidental secret commits