### PR TITLE
feat: serial number lookup with range support and chain-of-custody trail

### DIFF
--- a/frontend/components/ProvenanceTrail.tsx
+++ b/frontend/components/ProvenanceTrail.tsx
@@ -3,7 +3,7 @@
 import { colors } from "../styles/design-system";
 
 interface ProvenanceEvent {
-  type: "registered" | "verified" | "minted" | "listed" | "purchased" | "retired";
+  type: "registered" | "verified" | "minted" | "listed" | "purchased" | "transferred" | "retired";
   label: string;
   timestamp: string;
   actor?: string;
@@ -21,6 +21,7 @@ const eventConfig: Record<ProvenanceEvent["type"], { icon: string; color: string
   minted:     { icon: "🌱", color: colors.primary[700] },
   listed:     { icon: "🏪", color: "#2563eb" },
   purchased:  { icon: "💼", color: "#7c3aed" },
+  transferred:{ icon: "↔️", color: "#0891b2" },
   retired:    { icon: "🔒", color: colors.primary[800] },
 };
 

--- a/frontend/components/SerialNumberLookup.tsx
+++ b/frontend/components/SerialNumberLookup.tsx
@@ -1,18 +1,157 @@
 "use client";
 
 import { useState } from "react";
-import { useSerialLookup } from "../lib/api";
+import { useSerialSingleLookup, useSerialRangeLookup, SerialLookupResult } from "../lib/api";
+import ProvenanceTrail from "./ProvenanceTrail";
 import { colors } from "../styles/design-system";
 
-export default function SerialNumberLookup() {
-  const [serial, setSerial] = useState("");
-  const [search, setSearch] = useState("");
-  const { data, isLoading, error } = useSerialLookup(search);
+// ── Input mode toggle ─────────────────────────────────────────────────────────
 
-  function handleSearch(e: React.FormEvent) {
+type Mode = "single" | "range";
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function CreditDetails({ result }: { result: SerialLookupResult }) {
+  const isRetired = result.status === "retired";
+
+  return (
+    <div style={{
+      background: isRetired ? colors.primary[50] : colors.neutral[50],
+      border: `1px solid ${isRetired ? colors.primary[200] : colors.neutral[200]}`,
+      borderRadius: "0.5rem",
+      padding: "1rem",
+      marginBottom: "1rem",
+    }}>
+      {/* Status header */}
+      <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginBottom: "0.75rem" }}>
+        <span style={{ fontSize: "1.1rem" }}>{isRetired ? "🔒" : "🌱"}</span>
+        <span style={{ fontWeight: 700, fontSize: "0.9rem", color: isRetired ? colors.primary[800] : colors.primary[700] }}>
+          {isRetired ? "Permanently Retired" : "Active Credit"}
+        </span>
+        <span style={{
+          marginLeft: "auto",
+          fontSize: "0.7rem", fontWeight: 600,
+          background: isRetired ? colors.primary[100] : colors.neutral[100],
+          color: isRetired ? colors.primary[700] : colors.neutral[600],
+          border: `1px solid ${isRetired ? colors.primary[200] : colors.neutral[200]}`,
+          borderRadius: "9999px", padding: "0.15rem 0.6rem",
+        }}>
+          #{result.serialNumber}
+        </span>
+      </div>
+
+      {/* Core fields */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "0.6rem", marginBottom: "0.75rem" }}>
+        {[
+          ["Batch ID",     result.batchId],
+          ["Project",      result.projectName ?? result.projectId],
+          ["Vintage Year", result.vintageYear],
+          ["Methodology",  result.methodology ?? "—"],
+          ["Country",      result.country ?? "—"],
+          ["Current Owner", result.currentOwner ?? "—"],
+        ].map(([label, value]) => (
+          <div key={label as string}>
+            <p style={{ fontSize: "0.68rem", color: colors.neutral[500], margin: "0 0 0.1rem", textTransform: "uppercase", letterSpacing: "0.04em" }}>
+              {label}
+            </p>
+            <p style={{ fontSize: "0.82rem", fontWeight: 600, color: colors.neutral[800], margin: 0, wordBreak: "break-all" }}>
+              {value as string}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* Retirement-specific fields */}
+      {isRetired && (
+        <>
+          <div style={{
+            borderTop: `1px solid ${colors.primary[200]}`,
+            paddingTop: "0.75rem",
+            display: "grid", gridTemplateColumns: "1fr 1fr", gap: "0.6rem",
+            marginBottom: "0.75rem",
+          }}>
+            {[
+              ["Beneficiary",       result.beneficiary ?? "—"],
+              ["Retirement Reason", result.retirementReason ?? "—"],
+              ["Retired On",        result.retiredAt ? new Date(result.retiredAt).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" }) : "—"],
+              ["Tx Hash",           result.txHash ? result.txHash.slice(0, 18) + "…" : "—"],
+            ].map(([label, value]) => (
+              <div key={label as string}>
+                <p style={{ fontSize: "0.68rem", color: colors.neutral[500], margin: "0 0 0.1rem", textTransform: "uppercase", letterSpacing: "0.04em" }}>
+                  {label}
+                </p>
+                <p style={{ fontSize: "0.82rem", fontWeight: 600, color: colors.neutral[800], margin: 0, wordBreak: "break-all" }}>
+                  {value as string}
+                </p>
+              </div>
+            ))}
+          </div>
+          {result.retirementId && (
+            <a
+              href={`/retire/${result.retirementId}`}
+              style={{ fontSize: "0.8rem", color: colors.primary[600], fontWeight: 600 }}
+            >
+              View Retirement Certificate →
+            </a>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function ProvenanceSection({ result }: { result: SerialLookupResult }) {
+  if (!result.provenance?.length) return null;
+  return (
+    <div>
+      <p style={{ fontSize: "0.75rem", fontWeight: 700, color: colors.neutral[600], textTransform: "uppercase", letterSpacing: "0.05em", margin: "0 0 0.75rem" }}>
+        Chain of Custody
+      </p>
+      <ProvenanceTrail events={result.provenance} />
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export default function SerialNumberLookup() {
+  const [mode, setMode] = useState<Mode>("single");
+  const [singleInput, setSingleInput] = useState("");
+  const [rangeStart, setRangeStart] = useState("");
+  const [rangeEnd, setRangeEnd] = useState("");
+
+  // Committed search state (only set on submit)
+  const [committedSingle, setCommittedSingle] = useState("");
+  const [committedRange, setCommittedRange] = useState<{ start: string; end: string } | null>(null);
+
+  const { data: singleResult, isLoading: singleLoading, error: singleError } =
+    useSerialSingleLookup(committedSingle);
+
+  const { data: rangeResults, isLoading: rangeLoading, error: rangeError } =
+    useSerialRangeLookup(committedRange?.start ?? "", committedRange?.end ?? "");
+
+  function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    setSearch(serial.trim());
+    if (mode === "single") {
+      setCommittedSingle(singleInput.trim());
+      setCommittedRange(null);
+    } else {
+      setCommittedRange({ start: rangeStart.trim(), end: rangeEnd.trim() });
+      setCommittedSingle("");
+    }
   }
+
+  const isLoading = mode === "single" ? singleLoading : rangeLoading;
+  const error     = mode === "single" ? singleError  : rangeError;
+
+  const inputStyle = {
+    border: `1px solid ${colors.neutral[300]}`,
+    borderRadius: "0.5rem",
+    padding: "0.6rem 1rem",
+    fontSize: "0.875rem",
+    fontFamily: "monospace",
+    outline: "none",
+  };
 
   return (
     <div style={{
@@ -21,30 +160,66 @@ export default function SerialNumberLookup() {
       borderRadius: "0.75rem",
       padding: "1.5rem",
     }}>
-      <h3 style={{ fontSize: "1rem", fontWeight: 700, color: colors.neutral[900], margin: "0 0 1rem" }}>
+      <h3 style={{ fontSize: "1rem", fontWeight: 700, color: colors.neutral[900], margin: "0 0 0.25rem" }}>
         Serial Number Lookup
       </h3>
-      <p style={{ fontSize: "0.875rem", color: colors.neutral[500], margin: "0 0 1rem" }}>
-        Enter any credit serial number to see its complete history — from issuance to retirement.
+      <p style={{ fontSize: "0.8rem", color: colors.neutral[500], margin: "0 0 1rem" }}>
+        Enter any credit serial number to see its complete chain of custody — minted → transferred → retired.
       </p>
 
-      <form onSubmit={handleSearch} style={{ display: "flex", gap: "0.75rem", marginBottom: "1.5rem" }}>
-        <input
-          type="text"
-          placeholder="e.g. 1042"
-          value={serial}
-          onChange={e => setSerial(e.target.value)}
-          style={{
-            flex: 1,
-            border: `1px solid ${colors.neutral[300]}`,
-            borderRadius: "0.5rem",
-            padding: "0.6rem 1rem",
-            fontSize: "0.875rem",
-            fontFamily: "monospace",
-          }}
-        />
+      {/* Mode toggle */}
+      <div style={{ display: "flex", gap: "0.5rem", marginBottom: "1rem" }}>
+        {(["single", "range"] as Mode[]).map(m => (
+          <button
+            key={m}
+            onClick={() => setMode(m)}
+            style={{
+              padding: "0.3rem 0.9rem",
+              fontSize: "0.8rem", fontWeight: 600,
+              borderRadius: "9999px",
+              border: `1px solid ${mode === m ? colors.primary[600] : colors.neutral[300]}`,
+              background: mode === m ? colors.primary[600] : "transparent",
+              color: mode === m ? "#fff" : colors.neutral[600],
+              cursor: "pointer",
+            }}
+          >
+            {m === "single" ? "Single" : "Range"}
+          </button>
+        ))}
+      </div>
+
+      {/* Search form */}
+      <form onSubmit={handleSubmit} style={{ display: "flex", gap: "0.5rem", marginBottom: "1.25rem", flexWrap: "wrap" }}>
+        {mode === "single" ? (
+          <input
+            type="text"
+            placeholder="e.g. 1042"
+            value={singleInput}
+            onChange={e => setSingleInput(e.target.value)}
+            style={{ ...inputStyle, flex: 1, minWidth: "8rem" }}
+          />
+        ) : (
+          <>
+            <input
+              type="text"
+              placeholder="Start e.g. 1001"
+              value={rangeStart}
+              onChange={e => setRangeStart(e.target.value)}
+              style={{ ...inputStyle, flex: 1, minWidth: "7rem" }}
+            />
+            <span style={{ alignSelf: "center", color: colors.neutral[400], fontSize: "0.875rem" }}>–</span>
+            <input
+              type="text"
+              placeholder="End e.g. 1050"
+              value={rangeEnd}
+              onChange={e => setRangeEnd(e.target.value)}
+              style={{ ...inputStyle, flex: 1, minWidth: "7rem" }}
+            />
+          </>
+        )}
         <button
           type="submit"
+          disabled={mode === "single" ? !singleInput.trim() : !rangeStart.trim() || !rangeEnd.trim()}
           style={{
             background: colors.primary[600],
             color: "#fff",
@@ -54,71 +229,42 @@ export default function SerialNumberLookup() {
             fontSize: "0.875rem",
             fontWeight: 600,
             cursor: "pointer",
+            opacity: (mode === "single" ? !singleInput.trim() : !rangeStart.trim() || !rangeEnd.trim()) ? 0.5 : 1,
           }}
         >
           Look Up
         </button>
       </form>
 
-      {isLoading && <p style={{ color: colors.neutral[400], fontSize: "0.875rem" }}>Searching…</p>}
-      {error && <p style={{ color: "#dc2626", fontSize: "0.875rem" }}>Serial number not found.</p>}
+      {/* States */}
+      {isLoading && (
+        <p style={{ color: colors.neutral[400], fontSize: "0.875rem" }}>Searching…</p>
+      )}
+      {error && !isLoading && (
+        <p style={{ color: "#dc2626", fontSize: "0.875rem" }}>
+          {mode === "single" ? "Serial number not found." : "No credits found in that range."}
+        </p>
+      )}
 
-      {data && (
-        <div style={{
-          background: colors.primary[50],
-          border: `1px solid ${colors.primary[200]}`,
-          borderRadius: "0.5rem",
-          padding: "1rem",
-        }}>
-          {"retirementId" in data ? (
-            <>
-              <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginBottom: "0.75rem" }}>
-                <span style={{ fontSize: "1.25rem" }}>🔒</span>
-                <span style={{ fontWeight: 700, color: colors.primary[800] }}>Permanently Retired</span>
-              </div>
-              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "0.75rem" }}>
-                {[
-                  ["Retirement ID", (data as any).retirementId],
-                  ["Beneficiary",   (data as any).beneficiary],
-                  ["Project",       (data as any).projectId],
-                  ["Vintage Year",  (data as any).vintageYear],
-                  ["Retired At",    new Date((data as any).retiredAt).toLocaleDateString()],
-                  ["Tx Hash",       (data as any).txHash?.slice(0, 20) + "…"],
-                ].map(([label, value]) => (
-                  <div key={label}>
-                    <p style={{ fontSize: "0.7rem", color: colors.neutral[500], margin: "0 0 0.1rem" }}>{label}</p>
-                    <p style={{ fontSize: "0.85rem", fontWeight: 600, color: colors.neutral[800], margin: 0, wordBreak: "break-all" }}>{value}</p>
-                  </div>
-                ))}
-              </div>
-              <a
-                href={`/retire/${(data as any).retirementId}`}
-                style={{ display: "inline-block", marginTop: "0.75rem", fontSize: "0.8rem", color: colors.primary[600], fontWeight: 600 }}
-              >
-                View Full Certificate →
-              </a>
-            </>
-          ) : (
-            <>
-              <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginBottom: "0.75rem" }}>
-                <span style={{ fontSize: "1.25rem" }}>🌱</span>
-                <span style={{ fontWeight: 700, color: colors.primary[800] }}>Active Credit</span>
-              </div>
-              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "0.75rem" }}>
-                {[
-                  ["Batch ID",     (data as any).batchId],
-                  ["Project",      (data as any).projectId],
-                  ["Vintage Year", (data as any).vintageYear],
-                  ["Status",       (data as any).status],
-                ].map(([label, value]) => (
-                  <div key={label}>
-                    <p style={{ fontSize: "0.7rem", color: colors.neutral[500], margin: "0 0 0.1rem" }}>{label}</p>
-                    <p style={{ fontSize: "0.85rem", fontWeight: 600, color: colors.neutral[800], margin: 0 }}>{value}</p>
-                  </div>
-                ))}
-              </div>
-            </>
-          )}
+      {/* Single result */}
+      {!isLoading && !error && singleResult && mode === "single" && (
+        <>
+          <CreditDetails result={singleResult} />
+          <ProvenanceSection result={singleResult} />
+        </>
+      )}
+
+      {/* Range results */}
+      {!isLoading && !error && rangeResults && mode === "range" && (
+        <div>
+          <p style={{ fontSize: "0.8rem", color: colors.neutral[500], margin: "0 0 0.75rem" }}>
+            {rangeResults.length} credit{rangeResults.length !== 1 ? "s" : ""} found
+          </p>
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+            {rangeResults.map(r => (
+              <CreditDetails key={r.serialNumber} result={r} />
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -149,9 +149,51 @@ export function usePlatformStats() {
   });
 }
 
+export interface ProvenanceEvent {
+  type: "registered" | "verified" | "minted" | "listed" | "purchased" | "transferred" | "retired";
+  label: string;
+  timestamp: string;
+  actor?: string;
+  txHash?: string;
+  detail?: string;
+}
+
+export interface SerialLookupResult {
+  serialNumber: string;
+  batchId: string;
+  projectId: string;
+  projectName?: string;
+  vintageYear: number;
+  methodology?: string;
+  country?: string;
+  currentOwner?: string;
+  status: "active" | "retired";
+  // Retirement fields (present when status === "retired")
+  retirementId?: string;
+  beneficiary?: string;
+  retirementReason?: string;
+  retiredAt?: string;
+  txHash?: string;
+  // Chain of custody
+  provenance: ProvenanceEvent[];
+}
+
 export function useSerialLookup(serial: string) {
   return useSWR<RetirementRecord | CreditBatch>(
     serial ? `${API_URL}/credits/lookup/${serial}` : null,
+    fetcher,
+    swrConfig,
+  );
+}
+
+export function useSerialRangeLookup(start: string, end: string) {
+  const key = start && end ? `${API_URL}/credits/lookup?start=${encodeURIComponent(start)}&end=${encodeURIComponent(end)}` : null;
+  return useSWR<SerialLookupResult[]>(key, fetcher, swrConfig);
+}
+
+export function useSerialSingleLookup(serial: string) {
+  return useSWR<SerialLookupResult>(
+    serial ? `${API_URL}/credits/lookup/${encodeURIComponent(serial)}` : null,
     fetcher,
     swrConfig,
   );


### PR DESCRIPTION
 feat: serial number lookup with range support and chain-of-custody trail
  
  Implements the SerialNumberLookup component on the audit page with full credit
  provenance.
  
  Changes
  
  - Single serial or range input (start–end) with mode toggle
  - Returns project, batch ID, current owner, vintage year, methodology, and
  country for any credit
  - Retired credits show beneficiary, retirement reason, date, tx hash, and a
  direct certificate link
  - Full chain-of-custody timeline (minted → transferred → retired) via
  ProvenanceTrail
  - Added transferred event type to ProvenanceTrail
  - Added SerialLookupResult type and useSerialSingleLookup /
  useSerialRangeLookup hooks to api.ts
  - No wallet connection required — fully public read-only
  
  Testing
  
  - TypeScript types verified across all three changed files
  - Audit page at /audit renders the component in the right sidebar
  closes #9