### PR TITLE
feat: Admin Panel API, API Versioning, Marketplace Cache, Health Checks

### DIFF
--- a/backend/prisma/migrations/20260427000000_add_admin_config/migration.sql
+++ b/backend/prisma/migrations/20260427000000_add_admin_config/migration.sql
@@ -1,0 +1,8 @@
+-- CreateTable
+CREATE TABLE "AdminConfig" (
+    "key"       TEXT NOT NULL,
+    "value"     TEXT NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AdminConfig_pkey" PRIMARY KEY ("key")
+);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -258,3 +258,9 @@ model PriceApproval {
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 }
+
+model AdminConfig {
+  key       String   @id
+  value     String
+  updatedAt DateTime @updatedAt
+}

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -1,0 +1,69 @@
+import {
+  Controller, Get, Post, Delete, Body, Param, Query,
+  UseGuards, Request,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { RolesGuard, Roles } from '../auth/roles.guard';
+import { AdminService } from './admin.service';
+import { VerifierWhitelistDto, UpdateTreasuryDto } from './admin.dto';
+
+@Controller('admin')
+@UseGuards(AuthGuard('jwt'), RolesGuard)
+@Roles('admin')
+export class AdminController {
+  constructor(private readonly admin: AdminService) {}
+
+  // ── Verifier whitelist ──────────────────────────────────────────────────────
+
+  @Get('verifiers')
+  listVerifiers() {
+    return this.admin.listVerifiers();
+  }
+
+  @Post('verifiers')
+  addVerifier(@Body() dto: VerifierWhitelistDto) {
+    return this.admin.addVerifier(dto.address);
+  }
+
+  @Delete('verifiers/:address')
+  removeVerifier(@Param('address') address: string) {
+    return this.admin.removeVerifier(address);
+  }
+
+  // ── Treasury ────────────────────────────────────────────────────────────────
+
+  @Get('treasury')
+  getTreasury() {
+    return this.admin.getTreasury();
+  }
+
+  @Post('treasury')
+  updateTreasury(@Body() dto: UpdateTreasuryDto) {
+    return this.admin.updateTreasury(dto.address);
+  }
+
+  // ── Oracle health ───────────────────────────────────────────────────────────
+
+  @Get('oracle/health')
+  oracleHealth() {
+    return this.admin.getOracleHealth();
+  }
+
+  // ── Re-index ────────────────────────────────────────────────────────────────
+
+  @Post('reindex')
+  reindex() {
+    return this.admin.triggerReindex();
+  }
+
+  // ── Audit log ───────────────────────────────────────────────────────────────
+
+  @Get('audit-logs')
+  auditLogs(
+    @Query('limit')  limit?: number,
+    @Query('offset') offset?: number,
+    @Query('action') action?: string,
+  ) {
+    return this.admin.getAuditLogs({ limit, offset, action });
+  }
+}

--- a/backend/src/admin/admin.dto.ts
+++ b/backend/src/admin/admin.dto.ts
@@ -1,0 +1,9 @@
+import { IsString, IsEthereumAddress, IsOptional, Length } from 'class-validator';
+
+export class VerifierWhitelistDto {
+  @IsString() @Length(56, 56) address: string; // Stellar public key (G...)
+}
+
+export class UpdateTreasuryDto {
+  @IsString() @Length(56, 56) address: string;
+}

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
+import { IndexerModule } from '../indexer/indexer.module';
+import { OracleModule } from '../oracle/oracle.module';
+import { PrismaService } from '../prisma.service';
+
+@Module({
+  imports: [IndexerModule, OracleModule],
+  controllers: [AdminController],
+  providers: [AdminService, PrismaService],
+})
+export class AdminModule {}

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -1,0 +1,92 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma.service';
+import { IndexerService } from '../indexer/indexer.service';
+import { OracleService } from '../oracle/oracle.service';
+
+@Injectable()
+export class AdminService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly indexer: IndexerService,
+    private readonly oracle: OracleService,
+  ) {}
+
+  // ── Verifier whitelist ──────────────────────────────────────────────────────
+
+  addVerifier(address: string) {
+    return this.prisma.user.upsert({
+      where:  { publicKey: address },
+      update: { role: 'verifier' },
+      create: { publicKey: address, role: 'verifier' },
+    });
+  }
+
+  async removeVerifier(address: string) {
+    await this.prisma.user.update({
+      where: { publicKey: address },
+      data:  { role: 'corporation' },
+    });
+    return { removed: true, address };
+  }
+
+  listVerifiers() {
+    return this.prisma.user.findMany({ where: { role: 'verifier' } });
+  }
+
+  // ── Treasury ────────────────────────────────────────────────────────────────
+
+  async updateTreasury(address: string) {
+    // Stored as a named config entry in SyncMetadata-adjacent table.
+    // We use a simple key/value approach via a dedicated AdminConfig model.
+    return this.prisma.adminConfig.upsert({
+      where:  { key: 'treasury_address' },
+      update: { value: address },
+      create: { key: 'treasury_address', value: address },
+    });
+  }
+
+  getTreasury() {
+    return this.prisma.adminConfig.findUnique({ where: { key: 'treasury_address' } });
+  }
+
+  // ── Oracle health ───────────────────────────────────────────────────────────
+
+  async getOracleHealth() {
+    const approvals = await this.oracle.getPriceApprovals();
+    const pendingCount = approvals.filter(a => a.status === 'Pending').length;
+    const latestMonitoring = await this.prisma.monitoringData.findFirst({
+      orderBy: { submittedAt: 'desc' },
+    });
+    return {
+      pendingPriceApprovals: pendingCount,
+      latestMonitoringAt: latestMonitoring?.submittedAt ?? null,
+      isMonitoringCurrent: latestMonitoring
+        ? Date.now() - latestMonitoring.submittedAt.getTime() <= 365 * 24 * 60 * 60 * 1000
+        : false,
+    };
+  }
+
+  // ── Re-index ────────────────────────────────────────────────────────────────
+
+  async triggerReindex() {
+    // Reset the cursor so the next sync starts from ledger 0
+    await this.prisma.syncMetadata.update({
+      where: { id: 'singleton' },
+      data:  { lastIndexedLedger: 0 },
+    });
+    // Fire-and-forget; sync() is idempotent and guarded by isIndexing flag
+    this.indexer.sync().catch(() => null);
+    return { triggered: true };
+  }
+
+  // ── Audit log ───────────────────────────────────────────────────────────────
+
+  getAuditLogs(query: { limit?: number; offset?: number; action?: string }) {
+    return this.prisma.auditLog.findMany({
+      where:   query.action ? { action: { contains: query.action } } : undefined,
+      take:    Number(query.limit)  || 50,
+      skip:    Number(query.offset) || 0,
+      orderBy: { timestamp: 'desc' },
+    });
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,3 +1,4 @@
+import { AdminModule } from "./admin/admin.module";
 import { Module, Controller, Get } from "@nestjs/common";
 import { APP_INTERCEPTOR, APP_GUARD, APP_FILTER } from "@nestjs/core";
 import { BullModule } from "@nestjs/bullmq";
@@ -72,6 +73,7 @@ class HealthController {
     UploadsModule,
     AuditModule,
     VerifiersModule,
+    AdminModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/backend/src/export-openapi.ts
+++ b/backend/src/export-openapi.ts
@@ -1,5 +1,6 @@
 import { NestFactory } from "@nestjs/core";
 import { SwaggerModule, DocumentBuilder } from "@nestjs/swagger";
+import { VersioningType } from "@nestjs/common";
 import { writeFileSync } from "fs";
 import { resolve } from "path";
 import { AppModule } from "./app.module";
@@ -7,11 +8,16 @@ import { AppModule } from "./app.module";
 async function exportSpec() {
   const app = await NestFactory.create(AppModule, { logger: false });
   app.setGlobalPrefix("api/v1");
+  app.enableVersioning({ type: VersioningType.HEADER, header: "Accept-Version" });
 
   const config = new DocumentBuilder()
     .setTitle("CarbonLedger API")
     .setDescription(
       "Verified carbon credits. Permanent retirement. Full provenance.\n\n" +
+      "## Versioning\n" +
+      "All routes are served under `/api/v1/`. " +
+      "Clients may also pass `Accept-Version: 1` to explicitly request v1. " +
+      "See [API Deprecation Policy](../docs/api-versioning.md) for the full lifecycle policy.\n\n" +
       "## CarbonError codes\n" +
       "| Code | Name |\n" +
       "|------|------|\n" +
@@ -35,6 +41,7 @@ async function exportSpec() {
       "| 18 | InvalidSerialRange |"
     )
     .setVersion("1.0")
+    .addApiKey({ type: "apiKey", in: "header", name: "Accept-Version", description: "API version (e.g. 1)" }, "Accept-Version")
     .addBearerAuth()
     .build();
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,6 +1,7 @@
 import { NestFactory } from '@nestjs/core';
 import { ConsoleLogger, ForbiddenException, LogLevel, ValidationPipe, VersioningType } from '@nestjs/common';
 import { AppModule } from './app.module';
+import { PrismaService } from './prisma.service';
 
 /**
  * Minimal JSON logger — wraps NestJS ConsoleLogger so every line emitted to
@@ -75,8 +76,51 @@ async function bootstrap() {
    });
 
   const httpAdapter = app.getHttpAdapter();
+
+  // Liveness — process is alive
   httpAdapter.get('/health', (_req: any, res: any) => {
     res.status(200).json({ status: 'ok', timestamp: new Date().toISOString() });
+  });
+
+  // Readiness — DB and Redis must be reachable
+  httpAdapter.get('/health/ready', async (_req: any, res: any) => {
+    const checks: Record<string, string> = {};
+    let healthy = true;
+
+    // DB check
+    try {
+      const prisma = app.get(PrismaService);
+      await prisma.$queryRaw`SELECT 1`;
+      checks.db = 'ok';
+    } catch (err: any) {
+      checks.db = `error: ${err.message}`;
+      healthy = false;
+    }
+
+    // Redis check
+    try {
+      const Redis = require('ioredis');
+      const redis = new Redis({
+        host:        process.env.REDIS_HOST     || 'localhost',
+        port:        parseInt(process.env.REDIS_PORT || '6379'),
+        password:    process.env.REDIS_PASSWORD || undefined,
+        connectTimeout: 2000,
+        lazyConnect: true,
+      });
+      await redis.connect();
+      await redis.ping();
+      redis.disconnect();
+      checks.redis = 'ok';
+    } catch (err: any) {
+      checks.redis = `error: ${err.message}`;
+      healthy = false;
+    }
+
+    res.status(healthy ? 200 : 503).json({
+      status: healthy ? 'ok' : 'degraded',
+      checks,
+      timestamp: new Date().toISOString(),
+    });
   });
 
   await app.listen(process.env.PORT ?? 3001);

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,5 +1,5 @@
 import { NestFactory } from '@nestjs/core';
-import { ConsoleLogger, ForbiddenException, LogLevel, ValidationPipe } from '@nestjs/common';
+import { ConsoleLogger, ForbiddenException, LogLevel, ValidationPipe, VersioningType } from '@nestjs/common';
 import { AppModule } from './app.module';
 
 /**
@@ -35,6 +35,13 @@ async function bootstrap() {
   });
 
   app.setGlobalPrefix('api/v1');
+
+  // Header-based versioning: Accept-Version: 1
+  // All existing routes are VERSION_NEUTRAL (no @Version decorator needed).
+  app.enableVersioning({
+    type: VersioningType.HEADER,
+    header: 'Accept-Version',
+  });
 
   // Fix mass assignment (API3): strip unknown fields globally
   app.useGlobalPipes(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }));

--- a/backend/src/marketplace/listings-cache.service.ts
+++ b/backend/src/marketplace/listings-cache.service.ts
@@ -1,0 +1,66 @@
+import { Injectable, OnModuleDestroy, Logger } from '@nestjs/common';
+import Redis from 'ioredis';
+
+/** Simple hit/miss counters — reset on process restart, sufficient for metrics. */
+const metrics = { hits: 0, misses: 0 };
+
+export function getCacheMetrics() {
+  const total = metrics.hits + metrics.misses;
+  return {
+    hits:     metrics.hits,
+    misses:   metrics.misses,
+    hitRate:  total ? +(metrics.hits / total).toFixed(4) : 0,
+  };
+}
+
+@Injectable()
+export class ListingsCacheService implements OnModuleDestroy {
+  private readonly logger = new Logger(ListingsCacheService.name);
+  private readonly redis: Redis;
+  private readonly TTL = 60; // seconds
+
+  constructor() {
+    this.redis = new Redis({
+      host:     process.env.REDIS_HOST     || 'localhost',
+      port:     parseInt(process.env.REDIS_PORT || '6379'),
+      password: process.env.REDIS_PASSWORD || undefined,
+      lazyConnect: true,
+    });
+    this.redis.connect().catch(err =>
+      this.logger.warn(`Redis unavailable, caching disabled: ${err.message}`),
+    );
+  }
+
+  private key(suffix: string) {
+    return `listings:${suffix}`;
+  }
+
+  async get<T>(cacheKey: string): Promise<T | null> {
+    try {
+      const raw = await this.redis.get(this.key(cacheKey));
+      if (raw) { metrics.hits++;  return JSON.parse(raw) as T; }
+      metrics.misses++;
+      return null;
+    } catch {
+      metrics.misses++;
+      return null;
+    }
+  }
+
+  async set(cacheKey: string, value: unknown): Promise<void> {
+    try {
+      await this.redis.set(this.key(cacheKey), JSON.stringify(value), 'EX', this.TTL);
+    } catch { /* cache write failure is non-fatal */ }
+  }
+
+  async invalidateAll(): Promise<void> {
+    try {
+      const keys = await this.redis.keys(this.key('*'));
+      if (keys.length) await this.redis.del(...keys);
+    } catch { /* non-fatal */ }
+  }
+
+  onModuleDestroy() {
+    this.redis.disconnect();
+  }
+}

--- a/backend/src/marketplace/marketplace.module.ts
+++ b/backend/src/marketplace/marketplace.module.ts
@@ -1,12 +1,13 @@
 import { Module } from "@nestjs/common";
 import { MarketplaceController } from "./marketplace.controller";
 import { MarketplaceService } from "./marketplace.service";
+import { ListingsCacheService } from "./listings-cache.service";
 import { PrismaService } from "../prisma.service";
 import { AuthModule } from "../auth/auth.module";
 
 @Module({
   imports: [AuthModule],
   controllers: [MarketplaceController],
-  providers: [MarketplaceService, PrismaService],
+  providers: [MarketplaceService, ListingsCacheService, PrismaService],
 })
 export class MarketplaceModule {}

--- a/backend/src/marketplace/marketplace.service.ts
+++ b/backend/src/marketplace/marketplace.service.ts
@@ -2,12 +2,20 @@ import { Injectable, NotFoundException, BadRequestException } from "@nestjs/comm
 import { PrismaService } from "../prisma.service";
 import { CreateListingDto, PurchaseDto, BulkPurchaseDto, ListingsQueryDto, PaginatedListingsResponse } from "./marketplace.dto";
 import { randomBytes } from "crypto";
+import { ListingsCacheService } from "./listings-cache.service";
 
 @Injectable()
 export class MarketplaceService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly cache: ListingsCacheService,
+  ) {}
 
   async findAll(query: ListingsQueryDto): Promise<PaginatedListingsResponse> {
+    const cacheKey = JSON.stringify(query);
+    const cached = await this.cache.get<PaginatedListingsResponse>(cacheKey);
+    if (cached) return cached;
+
     const { methodology, vintage, country, minPrice, maxPrice, cursor, limit = 20 } = query;
 
     const where: any = {
@@ -37,7 +45,9 @@ export class MarketplaceService {
     const next_cursor = hasMore ? listings[listings.length - 2].id : undefined;
     if (hasMore) listings.pop();
 
-    return { listings, next_cursor, total_count };
+    const result = { listings, next_cursor, total_count };
+    await this.cache.set(cacheKey, result);
+    return result;
   }
 
   async findOne(listingId: string) {
@@ -48,7 +58,7 @@ export class MarketplaceService {
 
   async createListing(dto: CreateListingDto & { seller: string }) {
     // Fix mass assignment (API3): explicitly pick only allowed fields — never trust the full DTO object
-    return this.prisma.marketListing.create({
+    const result = await this.prisma.marketListing.create({
       data: {
         listingId:       dto.listingId,
         projectId:       dto.projectId,
@@ -62,14 +72,18 @@ export class MarketplaceService {
         status:          "Active",            // status is never accepted from the client
       },
     });
+    await this.cache.invalidateAll();
+    return result;
   }
 
   async delistListing(listingId: string) {
     await this.findOne(listingId);
-    return this.prisma.marketListing.update({
+    const result = await this.prisma.marketListing.update({
       where: { listingId },
       data:  { status: "Delisted" },
     });
+    await this.cache.invalidateAll();
+    return result;
   }
 
   async purchase(dto: PurchaseDto) {

--- a/backend/src/oracle/oracle.module.ts
+++ b/backend/src/oracle/oracle.module.ts
@@ -8,5 +8,6 @@ import { AuthModule } from "../auth/auth.module";
   imports: [AuthModule],
   controllers: [OracleController],
   providers: [OracleService, PrismaService],
+  exports: [OracleService],
 })
 export class OracleModule {}

--- a/backend/src/stats/stats.controller.ts
+++ b/backend/src/stats/stats.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get } from "@nestjs/common";
 import { StatsService } from "./stats.service";
+import { getCacheMetrics } from "../marketplace/listings-cache.service";
 
 @Controller("stats")
 export class StatsController {
@@ -8,5 +9,10 @@ export class StatsController {
   @Get()
   getStats() {
     return this.statsService.getPlatformStats();
+  }
+
+  @Get("cache")
+  getCacheStats() {
+    return { listings: getCacheMetrics() };
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,12 @@ services:
       LOG_LEVEL:         ${LOG_LEVEL:-info}
     ports:
       - "3001:3001"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3001/health/ready || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     command: >
       sh -c "npx prisma migrate deploy && node dist/main"
     logging: *default-logging
@@ -108,7 +114,8 @@ services:
       dockerfile: Dockerfile
     restart: unless-stopped
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     environment:
       NEXT_PUBLIC_API_URL:              http://localhost:3001/api/v1
       NEXT_PUBLIC_STELLAR_NETWORK:      ${STELLAR_NETWORK:-testnet}

--- a/docs/api-versioning.md
+++ b/docs/api-versioning.md
@@ -1,0 +1,51 @@
+# CarbonLedger API Versioning & Deprecation Policy
+
+## Current version
+
+All API routes are served under the `/api/v1/` path prefix.
+
+Clients may also signal the desired version via the request header:
+
+```
+Accept-Version: 1
+```
+
+If the header is omitted the request is routed to the current stable version (v1).
+
+## Version lifecycle
+
+| Stage | Duration | What happens |
+|-------|----------|--------------|
+| **Active** | Indefinite | Fully supported; breaking changes are never made |
+| **Deprecated** | Minimum 6 months | Still functional; every response includes `Deprecation: true` and `Sunset: <date>` headers |
+| **Sunset** | — | Version removed; requests return `410 Gone` |
+
+## What constitutes a breaking change
+
+- Removing or renaming an endpoint
+- Removing or renaming a required request field
+- Changing the type of a response field
+- Changing HTTP status codes for existing success paths
+- Removing enum values from existing fields
+
+Non-breaking changes (additions of optional fields, new endpoints, new enum values) are made in-place without a version bump.
+
+## Introducing a new version
+
+1. A new version (e.g. v2) is introduced by adding a second global prefix **and** enabling `VersioningType.HEADER` with `Accept-Version: 2`.
+2. The previous version enters **Deprecated** status on the same day.
+3. `Deprecation` and `Sunset` response headers are added to all v1 responses.
+4. After the 6-month minimum window the old version is removed.
+
+## Response headers during deprecation
+
+```
+Deprecation: true
+Sunset: Sat, 01 Jan 2028 00:00:00 GMT
+Link: <https://docs.carbonledger.io/api/v2>; rel="successor-version"
+```
+
+## OpenAPI spec
+
+The spec is generated at `docs/openapi.json` and reflects the current stable version.
+Run `npm run export:openapi` from the `backend/` directory to regenerate it.


### PR DESCRIPTION
## Summary

Closes #35
Closes #39
Closes #40
Closes #42

---

### #35 [BE-013] Admin Panel API

New `/admin` module — all endpoints require `admin` role JWT.

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/admin/verifiers` | List whitelisted verifiers |
| POST | `/admin/verifiers` | Add verifier address |
| DELETE | `/admin/verifiers/:address` | Remove verifier |
| GET/POST | `/admin/treasury` | Read/update treasury address |
| GET | `/admin/oracle/health` | Oracle freshness + pending price approvals |
| POST | `/admin/reindex` | Reset ledger cursor, trigger full re-sync |
| GET | `/admin/audit-logs` | Paginated audit log |

Added `AdminConfig` Prisma model + migration. Exported `OracleService` from `OracleModule`.

---

### #39 [BE-017] API Versioning

- All routes already under `/api/v1/` global prefix
- Added NestJS `VersioningType.HEADER` (`Accept-Version` header) in `main.ts` and `export-openapi.ts`
- Added `docs/api-versioning.md`: lifecycle stages, breaking-change definition, `Deprecation`/`Sunset` response headers

---

### #40 [BE-018] Caching Layer for Marketplace Listings

- `ListingsCacheService` wraps `ioredis` with 60s TTL on `listings:*` keys
- Cache miss falls through to DB transparently; Redis errors are non-fatal
- `createListing` and `delistListing` invalidate all `listings:*` keys
- `GET /api/v1/stats/cache` exposes `{ hits, misses, hitRate }`

---

### #42 [BE-020] Health Check Endpoints

- `GET /health` — liveness, always 200
- `GET /health/ready` — readiness, checks DB (`SELECT 1`) + Redis (`PING`); returns 503 with `{ status: 'degraded', checks }` on failure
- `docker-compose.yml`: backend `healthcheck` on `/health/ready`; frontend `depends_on` backend with `service_healthy`

---

## Testing

`tsc --noEmit` passes (only pre-existing `baseUrl` deprecation warning). All changes are additive and non-breaking.