### PR TITLE
ci: add security-tests job and block e2e on security pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,64 @@ jobs:
             --method POST \
             --field body="$(printf '%b' "$REPORT")"
 
+  security-tests:
+    name: Security Tests (XSS / SQL Injection)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: carbonledger_security
+          POSTGRES_USER: carbonledger
+          POSTGRES_PASSWORD: securitytestpassword
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: backend
+        run: npm ci
+
+      - name: Generate Prisma client
+        working-directory: backend
+        env:
+          DATABASE_URL: postgresql://carbonledger:securitytestpassword@localhost:5432/carbonledger_security
+        run: npx prisma generate
+
+      - name: Run database migrations
+        working-directory: backend
+        env:
+          DATABASE_URL: postgresql://carbonledger:securitytestpassword@localhost:5432/carbonledger_security
+        run: npx prisma migrate deploy
+
+      - name: Run security tests (XSS + SQL injection)
+        working-directory: backend
+        env:
+          DATABASE_URL: postgresql://carbonledger:securitytestpassword@localhost:5432/carbonledger_security
+          JWT_SECRET: security-test-secret
+          REDIS_HOST: localhost
+          REDIS_PORT: 6379
+        run: |
+          npx jest --testPathPattern="src/security/(xss|sql-injection|injection|owasp-top10|auth-bypass|idor|privilege-escalation)\.spec\.ts" \
+            --forceExit --runInBand
+
   backend:
     name: NestJS Backend
     runs-on: ubuntu-latest
@@ -302,6 +360,7 @@ jobs:
   e2e:
     name: Playwright E2E Tests
     runs-on: ubuntu-latest
+    needs: [backend, frontend, security-tests]
     services:
       postgres:
         image: postgres:16-alpine


### PR DESCRIPTION
- Add dedicated security-tests job that runs all backend security specs (xss, sql-injection, injection, owasp-top10, auth-bypass, idor, privilege-escalation)
- Job spins up Postgres + Redis services matching the backend test environment
- Runs migrations before tests to ensure schema is current
- e2e job now depends on backend, frontend, and security-tests (needs: [...]) so PRs cannot be merged if any security test fails
- Security tests reported as a separate named check in PR status

Closes #425