### PR TITLE
test: k6 performance tests for marketplace listings endpoint

### DIFF
--- a/scripts/perf-test-listings.js
+++ b/scripts/perf-test-listings.js
@@ -1,0 +1,101 @@
+/**
+ * k6 performance test — GET /marketplace/listings
+ *
+ * Targets:
+ *   - p95 < 500ms  (warm cache)
+ *   - p95 < 2000ms (cold cache)
+ *   - 100 concurrent virtual users, 60-second duration
+ *
+ * Usage:
+ *   # Warm cache (default)
+ *   k6 run scripts/perf-test-listings.js
+ *
+ *   # Cold cache
+ *   k6 run -e CACHE=cold scripts/perf-test-listings.js
+ *
+ *   # Custom base URL
+ *   k6 run -e BASE_URL=http://localhost:3001 scripts/perf-test-listings.js
+ */
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend, Rate } from 'k6/metrics';
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+const CACHE    = __ENV.CACHE   || 'warm';   // 'warm' | 'cold'
+
+const P95_THRESHOLD = CACHE === 'cold' ? 2000 : 500;
+
+// ── k6 options ────────────────────────────────────────────────────────────────
+
+export const options = {
+  vus:      100,
+  duration: '60s',
+  thresholds: {
+    // Primary acceptance criteria
+    'http_req_duration{scenario:listings}': [
+      `p(95)<${P95_THRESHOLD}`,
+    ],
+    // Sanity: no more than 1% errors
+    'http_req_failed': ['rate<0.01'],
+  },
+};
+
+// ── Query param variants — exercises filters the endpoint supports ─────────────
+
+const QUERY_VARIANTS = [
+  '',
+  '?limit=20',
+  '?methodology=REDD%2B',
+  '?vintage=2023',
+  '?country=Brazil',
+  '?methodology=VCS&vintage=2022&limit=10',
+  '?minPrice=5&maxPrice=20',
+  '?search=forest',
+];
+
+// ── Main VU loop ──────────────────────────────────────────────────────────────
+
+export default function () {
+  const query = QUERY_VARIANTS[Math.floor(Math.random() * QUERY_VARIANTS.length)];
+  const url   = `${BASE_URL}/marketplace/listings${query}`;
+
+  const res = http.get(url, {
+    tags: { scenario: 'listings' },
+    headers: { Accept: 'application/json' },
+  });
+
+  check(res, {
+    'status 200':        (r) => r.status === 200,
+    'has listings array': (r) => {
+      try { return Array.isArray(JSON.parse(r.body).listings); }
+      catch { return false; }
+    },
+  });
+
+  // Minimal think-time: real browsers don't hammer with zero delay
+  sleep(0.1);
+}
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+
+export function handleSummary(data) {
+  const dur  = data.metrics.http_req_duration;
+  const pass = data.thresholds?.['http_req_duration{scenario:listings}']?.ok ?? false;
+
+  console.log('\n=== Marketplace Listings — Performance Summary ===');
+  console.log(`Cache mode : ${CACHE}`);
+  console.log(`p50        : ${dur.values['p(50)'].toFixed(1)} ms`);
+  console.log(`p95        : ${dur.values['p(95)'].toFixed(1)} ms  (threshold: <${P95_THRESHOLD} ms) ${pass ? '✓ PASS' : '✗ FAIL'}`);
+  console.log(`p99        : ${dur.values['p(99)'].toFixed(1)} ms`);
+  console.log(`req/s      : ${data.metrics.http_reqs.values.rate.toFixed(1)}`);
+  console.log(`errors     : ${(data.metrics.http_req_failed.values.rate * 100).toFixed(2)}%`);
+  console.log('=================================================\n');
+
+  return {
+    stdout: '',  // already printed above
+    'scripts/perf-results-listings.json': JSON.stringify(data, null, 2),
+  };
+}

--- a/scripts/run-perf-tests.sh
+++ b/scripts/run-perf-tests.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# scripts/run-perf-tests.sh
+#
+# Runs the marketplace listings performance test (warm + cold cache).
+# Requires k6: https://k6.io/docs/get-started/installation/
+#
+# Usage:
+#   ./scripts/run-perf-tests.sh [BASE_URL]
+#
+# Examples:
+#   ./scripts/run-perf-tests.sh
+#   ./scripts/run-perf-tests.sh http://localhost:3001
+
+set -euo pipefail
+
+BASE_URL="${1:-http://localhost:3000}"
+SCRIPT="$(dirname "$0")/perf-test-listings.js"
+
+if ! command -v k6 &>/dev/null; then
+  echo "ERROR: k6 not found. Install from https://k6.io/docs/get-started/installation/"
+  exit 1
+fi
+
+echo "=== CarbonLedger — Marketplace Listings Performance Test ==="
+echo "Target: ${BASE_URL}"
+echo ""
+
+# ── Warm cache run ────────────────────────────────────────────────────────────
+echo "--- Warm cache (p95 target: <500ms) ---"
+k6 run -e BASE_URL="${BASE_URL}" -e CACHE=warm "${SCRIPT}"
+
+# ── Cold cache run ────────────────────────────────────────────────────────────
+echo ""
+echo "--- Cold cache (p95 target: <2000ms) ---"
+echo "Flushing Redis cache via API..."
+curl -sf -X POST "${BASE_URL}/marketplace/cache/flush" \
+  -H "Authorization: Bearer ${ADMIN_TOKEN:-}" \
+  -o /dev/null || echo "  (cache flush skipped — set ADMIN_TOKEN or flush manually)"
+
+k6 run -e BASE_URL="${BASE_URL}" -e CACHE=cold "${SCRIPT}"
+
+echo ""
+echo "Results saved to scripts/perf-results-listings.json"


### PR DESCRIPTION
## Summary

Closes #422. Adds k6 performance tests for `GET /marketplace/listings` — the highest-traffic endpoint — to verify latency targets before mainnet launch.

## Changes

- `scripts/perf-test-listings.js` — k6 test: 100 VUs, 60s duration, 8 query variants (filters, pagination, search), enforced thresholds, outputs p50/p95/p99 summary and saves `perf-results-listings.json`
- `scripts/run-perf-tests.sh` — runner that executes warm-cache then cold-cache passes, with optional Redis flush between them

## Acceptance Criteria

| Criteria | How it's met |
|---|---|
| 100 concurrent users | `vus: 100` in k6 options |
| p95 < 500ms warm cache | threshold on `http_req_duration{scenario:listings}` |
| p95 < 2000ms cold cache | same threshold, `CACHE=cold` env var |
| 60-second run | `duration: '60s'` |
| Reports p50, p95, p99 | `handleSummary` prints all three |
| Runnable from scripts/ | `./scripts/run-perf-tests.sh` |

## How to Run

```bash
# Install k6 (one-time): https://k6.io/docs/get-started/installation/

# Both warm + cold passes
./scripts/run-perf-tests.sh http://localhost:3000

# Warm only
k6 run scripts/perf-test-listings.js

# Cold only
k6 run -e CACHE=cold scripts/perf-test-listings.js
```