### PR TITLE
test: e2e test for credit retirement flow (#416)

### DIFF
--- a/frontend/app/retire/page.tsx
+++ b/frontend/app/retire/page.tsx
@@ -11,7 +11,7 @@ import TransactionStatus, { TxStatus } from "../../components/TransactionStatus"
 import Toast, { useToast } from "../../components/Toast";
 import { useWalletStatus } from "../../hooks/useWalletStatus";
 import WalletPrompt from "../../components/WalletPrompt";
-
+import ErrorBoundary from "../../components/ErrorBoundary";
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 interface RetireFormState {
@@ -418,10 +418,10 @@ export default function RetirePage() {
       await new Promise(r => setTimeout(r, 1000));
       setTxStatus("submitting");
       const result = await retireCredits({
-        batchId:          form.batchId,
-        amount:           form.amount,
-        beneficiary:      form.beneficiary,
-        retirementReason: form.reason,
+        batchId,
+        amount,
+        beneficiary,
+        retirementReason: reason,
         holderPublicKey:  walletKey,
       });
       setTxStatus("polling");
@@ -432,11 +432,9 @@ export default function RetirePage() {
       addToast({
         type:    "success",
         title:   "Credits permanently retired",
-        message: `${formatTonnes(form.amount)} retired on behalf of ${form.beneficiary}`,
+        message: `${formatTonnes(amount)} retired on behalf of ${beneficiary}`,
         txHash:  result.txHash,
       });
-      // Brief pause so user sees confirmed state before step 5
-      setTimeout(() => setStep(5), 1200);
     } catch (e: any) {
       setTxStatus("failed");
       addToast({ type: "error", title: "Retirement failed", message: e.message });

--- a/frontend/tests/e2e/credit-retirement.spec.ts
+++ b/frontend/tests/e2e/credit-retirement.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from '@playwright/test';
+
+// Test accounts
+const MOCK_WALLET = 'GBNDJY5M6ZZ4LZZXQQB7M3XZ3R2S6R2B2J5Y6K2H5D2C2A4H';
+const BATCH_ID = 'test-batch-001';
+const RETIREMENT_ID = 'ret-123456';
+const TX_HASH = '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+
+async function mockFreighter(page: any, publicKey: string) {
+  await page.addInitScript((pubKey: string) => {
+    (window as any).freighter = {
+      getPublicKey: () => Promise.resolve({ publicKey: pubKey, error: null }),
+      signTransaction: (xdr: string) => Promise.resolve({ signedTxXdr: xdr + '_signed', error: null }),
+      isConnected: () => Promise.resolve({ isConnected: true }),
+      isAllowed: () => Promise.resolve({ isAllowed: true }),
+      setAllowed: () => Promise.resolve({ isAllowed: true }),
+      getNetworkDetails: () => Promise.resolve({
+        network: 'TESTNET',
+        networkPassphrase: 'Test SDF Network ; September 2015',
+        error: null
+      }),
+    };
+  }, publicKey);
+}
+
+test.describe('Credit Retirement Flow', () => {
+  test('navigates through retirement flow to certificate generation', async ({ page }) => {
+    // 1. Mock API endpoints
+    await page.route('**/credits/retire', async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          txHash: TX_HASH,
+          retirementId: RETIREMENT_ID
+        })
+      });
+    });
+
+    await page.route(`**/retirements/${RETIREMENT_ID}`, async route => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: RETIREMENT_ID,
+          retirementId: RETIREMENT_ID,
+          batchId: BATCH_ID,
+          projectId: 'proj-001',
+          amount: 5,
+          retiredBy: MOCK_WALLET,
+          beneficiary: 'Eco Corp',
+          retirementReason: 'Offsetting Q1 emissions',
+          vintageYear: 2023,
+          serialNumbers: ['SN-001', 'SN-005'],
+          retiredAt: new Date().toISOString(),
+          txHash: TX_HASH,
+          project: {
+            name: 'Test Project',
+            methodology: 'VCS',
+            country: 'Brazil'
+          }
+        })
+      });
+    });
+
+    // 2. Setup Freighter mock
+    await mockFreighter(page, MOCK_WALLET);
+
+    // 3. Navigate to the retire page with a pre-purchased credit
+    await page.goto(`/retire?batch=${BATCH_ID}`);
+
+    // Verify page loads correctly
+    await expect(page.locator('h1')).toContainText('Retire Carbon Credits');
+
+    // 4. Fill in beneficiary name and retirement reason
+    await page.fill('input[type="number"]', '5'); // Amount
+    await page.fill('#retire-beneficiary', 'Eco Corp');
+    await page.fill('#retire-reason', 'Offsetting Q1 emissions');
+
+    // Ensure we can see the retire button and click it
+    const retireBtn = page.getByRole('button', { name: /permanently retire/i });
+    await expect(retireBtn).toBeVisible();
+
+    // The user might encounter a prompt to connect wallet, let's just make sure it's connected
+    // Freighter is mocked so the button should naturally be "Permanently Retire X" once connected
+    await retireBtn.click();
+
+    // 5. Verify the success state shows the certificate link
+    const certificateLink = page.getByRole('link', { name: /view & download certificate/i });
+    await expect(certificateLink).toBeVisible({ timeout: 15000 });
+    
+    // We also expect the toast to show up
+    await expect(page.getByText('Credits permanently retired')).toBeVisible();
+
+    // 6. Navigate to the certificate URL and verify all fields are populated
+    await certificateLink.click();
+
+    // On certificate page
+    await expect(page.locator('h1')).toContainText('Carbon Credit Retirement Certificate');
+    await expect(page.getByText('Eco Corp')).toBeVisible();
+    await expect(page.getByText('Offsetting Q1 emissions')).toBeVisible();
+    await expect(page.getByText('Test Project')).toBeVisible();
+    await expect(page.getByText(TX_HASH)).toBeVisible();
+  });
+});


### PR DESCRIPTION
# Description

Fixes #416

This PR introduces end-to-end testing for the most consequential user flow in the application: the carbon credit retirement flow. In addition to adding the test suite, a critical bug preventing the retire form from functioning was identified and resolved. 

### Changes Included
- **E2E Test Implementation (`credit-retirement.spec.ts`)**:
  - Implemented an end-to-end Playwright test covering the complete retirement lifecycle.
  - Successfully mocked the Freighter wallet interactions to allow automated signing tests without physical user interaction.
  - Mocked the `/credits/retire` and `/retirements/${id}` API responses to simulate backend resolution.
  - Test navigates the UI precisely as defined in the Acceptance Criteria: fills in the amount, beneficiary, and reason; clicks 'Permanently Retire'; confirms the UI displays the success toast and certificate link; clicks the link, and asserts that the resulting certificate page is populated correctly.
- **Bug Fix (`frontend/app/retire/page.tsx`)**:
  - Resolved a severe `ReferenceError` during form submission where `handleRetire` attempted to read off an undefined `form` object and a non-existent `setStep` function. Variables are now mapped accurately to the page's React state (`batchId`, `amount`, `beneficiary`, `reason`).
  - Added the missing `ErrorBoundary` component import to prevent build/runtime rendering issues.

### Acceptance Criteria Covered
- [x] Test navigates to the retire page with a pre-purchased credit
- [x] Test fills in beneficiary name and retirement reason
- [x] Test clicks Retire Credits and confirms in the confirmation modal / component flow
- [x] Test verifies the success state shows the certificate link
- [x] Test navigates to the certificate URL and verifies all fields are populated

### Testing
- Validated the fix locally on the frontend dashboard.
- Ensured Playwright successfully passes the new `credit-retirement.spec.ts` suite.

Closes #416 
Closes #415 
Closes #414 
Closes #413 