### PR TITLE
docs: add carbon credit lifecycle reference and environment variable configuration guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,3 +81,9 @@ FRONTEND_URL=http://localhost:3000
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001,https://app.carbonledger.com
 # Maximum JSON request body size (express body-parser format: 10kb, 1mb, etc.)
 BODY_SIZE_LIMIT=10kb
+
+# ── Oracle Service (Python) ───────────────────────────────────────────────────
+# Base URL of the backend API — oracle services post monitoring results here.
+BACKEND_API_URL=http://localhost:3001/api/v1
+# Pre-issued JWT for the oracle service account to authenticate with the backend.
+BACKEND_JWT_TOKEN=

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@
 - ✅ **[Setup Checklist](docs/SETUP_CHECKLIST.md)** - Verify your environment
 - 🔧 **[Troubleshooting](docs/TROUBLESHOOTING.md)** - Common issues solved
 - 📋 **[Quick Reference](docs/QUICK_REFERENCE.md)** - One-page command reference
+- 🔑 **[Configuration Guide](docs/configuration.md)** - Every environment variable explained
+- ♻️ **[Credit Lifecycle](docs/carbon-credit-lifecycle.md)** - Actors, contracts, data, and error conditions for each stage
 
 **Run this to verify your setup:**
 ```bash
@@ -527,6 +529,8 @@ Purchased by Corporation → Retired On-Chain (irreversible) →
 Certificate Issued (permanent public URL) →
 ESG Report Filed 
 ```
+
+> For the full lifecycle reference — actors involved, contract functions called, on-chain and off-chain data, error conditions, and a sequence diagram — see **[docs/carbon-credit-lifecycle.md](docs/carbon-credit-lifecycle.md)**.
 
 ---
 

--- a/docs/carbon-credit-lifecycle.md
+++ b/docs/carbon-credit-lifecycle.md
@@ -1,0 +1,824 @@
+# Carbon Credit Lifecycle
+
+> **Complete reference for the CarbonLedger credit lifecycle** — actors, contract functions, on-chain data, off-chain data, error conditions, and edge cases for each stage.
+
+---
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Actors](#actors)
+- [Sequence Diagram](#sequence-diagram)
+- [Stage 1 — Project Registration](#stage-1--project-registration)
+- [Stage 2 — Verification](#stage-2--verification)
+- [Stage 3 — Oracle Monitoring](#stage-3--oracle-monitoring)
+- [Stage 4 — Credit Minting](#stage-4--credit-minting)
+- [Stage 5 — Marketplace Listing](#stage-5--marketplace-listing)
+- [Stage 6 — Purchase](#stage-6--purchase)
+- [Stage 7 — Retirement](#stage-7--retirement)
+- [Stage 8 — Certification](#stage-8--certification)
+- [Error Reference](#error-reference)
+
+---
+
+## Overview
+
+A carbon credit travels through eight stages from a real-world offset project to a permanent, publicly verifiable retirement record. Each stage maps to one or more Soroban contract calls and database writes. The lifecycle is designed so that fraud, double-counting, and greenwashing are prevented at the smart-contract level — not just by policy.
+
+```
+ Registration → Verification → Oracle Monitoring → Minting
+      ↓               ↓               ↓               ↓
+  Pending          Verified      Data on-chain    Serial numbers
+                                                   assigned
+                                                       ↓
+                                              Marketplace Listing
+                                                       ↓
+                                                   Purchase
+                                                       ↓
+                                                  Retirement  ←── IRREVERSIBLE
+                                                       ↓
+                                               Certification
+                                          (permanent public URL)
+```
+
+---
+
+## Actors
+
+| Actor | Role |
+|-------|------|
+| **Project Developer** | Registers projects, requests credit minting, receives USDC payments |
+| **Accredited Verifier** | Approves or rejects projects; submits on-chain attestations |
+| **Oracle Service** | Python bridge that posts satellite monitoring data and price feeds to contracts |
+| **Corporation** | Buys credits from the marketplace and retires them for ESG offset claims |
+| **Admin** | Deploys and upgrades contracts; maintains the verifier allow-list |
+| **Public / Auditor** | Read-only access to audit trail — no wallet required |
+
+---
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor Dev as Project Developer
+    actor Ver as Verifier
+    participant Oracle as Oracle Service<br/>(Python)
+    participant Reg as carbon_registry
+    participant Cred as carbon_credit
+    participant Mkt as carbon_marketplace
+    participant OraC as carbon_oracle
+    participant DB as PostgreSQL
+    participant IPFS as IPFS (Pinata)
+    actor Corp as Corporation
+
+    Dev->>IPFS: Upload project documentation
+    IPFS-->>Dev: metadata_cid
+    Dev->>Reg: register_project(project_id, metadata_cid, ...)
+    Reg-->>DB: status = Pending
+
+    Ver->>Reg: verify_project(verifier_address, project_id)
+    Reg-->>DB: status = Verified
+
+    loop Every 6 hours
+        Oracle->>Ver: Poll Gold Standard / Verra VCS APIs
+        Ver-->>Oracle: Monitoring report
+        Oracle->>IPFS: Upload satellite imagery
+        IPFS-->>Oracle: satellite_cid
+        Oracle->>OraC: submit_monitoring_data(project_id, period, tonnes_verified, satellite_cid, sig, nonce)
+        OraC-->>DB: MonitoringData stored
+    end
+
+    loop Every 12 hours
+        Oracle->>OraC: update_credit_price(methodology, vintage_year, price_usdc, sig, nonce)
+    end
+
+    Dev->>Cred: mint_credits(project_id, amount, serial_start, serial_end, ...)
+    Cred->>OraC: is_monitoring_current(project_id)
+    OraC-->>Cred: true
+    Cred->>Cred: verify_serial_range(serial_start, serial_end)
+    Cred-->>DB: CreditBatch created (status = Active)
+
+    Dev->>Mkt: list_credits(listing_id, batch_id, amount, price_per_credit_usdc, ...)
+    Mkt-->>DB: MarketListing created (status = Active)
+
+    Corp->>Mkt: purchase_credits(listing_id, amount)
+    Mkt->>Cred: transfer_credits(seller, buyer, batch_id, amount)
+    Mkt->>USDC: transfer(buyer → seller, total_cost)
+    Mkt-->>DB: listing status = Sold / PartiallyFilled
+
+    Corp->>IPFS: Upload certificate metadata
+    IPFS-->>Corp: certificate_cid
+    Corp->>Cred: retire_credits(batch_id, amount, retirement_id, beneficiary, reason, certificate_cid)
+    Note over Cred: PERMANENTLY IRREVERSIBLE
+    Cred-->>DB: RetirementRecord created
+    Cred-->>DB: CreditBatch status = FullyRetired / PartiallyRetired
+
+    DB->>IPFS: Generate and pin PDF certificate
+    IPFS-->>Corp: Public certificate URL (permanent)
+```
+
+---
+
+## Stage 1 — Project Registration
+
+**Summary:** A project developer submits a new carbon offset project for review. The project is stored on-chain with `Pending` status and cannot issue credits until a verifier approves it.
+
+### Actors Involved
+
+| Actor | Action |
+|-------|--------|
+| Project Developer | Fills registration form with project details and uploads documentation |
+| Admin | Signs the `register_project` transaction (acts as contract gatekeeper) |
+
+### Contract Called
+
+**Contract:** `carbon_registry`  
+**Function:** `register_project`
+
+```rust
+register_project(
+    env: Env,
+    admin: Address,
+    project_id: String,     // globally unique identifier (e.g. "REDD-2024-BRA-001")
+    name: String,
+    metadata_cid: String,   // IPFS CID pointing to project documentation
+    verifier_address: Address,
+    methodology: String,    // e.g. "REDD+", "VCS-VM0015", "Gold Standard"
+    country: String,        // ISO 3166-1 alpha-3
+    project_type: String,   // e.g. "reforestation", "blue_carbon", "methane_capture"
+    vintage_year: u32,      // baseline year (e.g. 2023)
+)
+```
+
+### Data Stored On-Chain
+
+Stored in `carbon_registry` contract storage under key `Project(project_id)`:
+
+```rust
+CarbonProject {
+    project_id: String,
+    name: String,
+    methodology: String,
+    country: String,
+    project_type: String,
+    verifier_address: Address,
+    metadata_cid: String,          // IPFS CID
+    total_credits_issued: i128,    // starts at 0
+    total_credits_retired: i128,   // starts at 0
+    methodology_score: u32,        // 0–100; must be ≥ 70 to advance
+    status: ProjectStatus::Pending,
+    vintage_year: u32,
+    created_at: u64,               // ledger timestamp
+}
+```
+
+### Data Stored Off-Chain
+
+| Store | Table / Object | Fields |
+|-------|---------------|--------|
+| PostgreSQL | `CarbonProject` | id, projectId, name, description, methodology, country, projectType, status, vintageYear, methodologyScore, metadataCid, verifierAddress, ownerAddress, coordinates (JSON), createdAt |
+| IPFS | Project documentation bundle | Project feasibility study, methodology application, land title or legal proof, baseline survey data |
+
+### Error Conditions
+
+| Error Code | Constant | Trigger |
+|-----------|----------|---------|
+| 17 | `ProjectAlreadyExists` | A project with the same `project_id` is already registered |
+| 20 | `MethodologyScoreLow` | Computed `methodology_score` is below 70 |
+| 19 | `AlreadyInitialized` | Contract `initialize()` called a second time |
+
+### Edge Cases
+
+- **Duplicate project IDs** are rejected at the contract level; the backend generates IDs using a combination of methodology code, vintage year, country, and a UUID suffix.
+- **Metadata CID validation** is done off-chain before submission — the backend verifies the CID resolves on the IPFS gateway before calling `register_project`.
+- **Verifier assignment** happens at registration time and cannot be changed without admin intervention.
+
+---
+
+## Stage 2 — Verification
+
+**Summary:** An accredited verifier reviews the project documentation and either approves or rejects it. Approval is an on-chain transaction that moves the project from `Pending` to `Verified`. Only verifiers on the contract's allow-list can call this function.
+
+### Actors Involved
+
+| Actor | Action |
+|-------|--------|
+| Accredited Verifier | Reviews off-chain docs, calls `verify_project` or `reject_project` |
+| Oracle Service | `verification_listener.py` polls Gold Standard and Verra VCS APIs every 6 hours for automated attestation signals |
+
+### Contracts Called
+
+**Contract:** `carbon_registry`
+
+```rust
+// Approve
+verify_project(
+    env: Env,
+    verifier_address: Address,  // must be in the Verifiers allow-list
+    project_id: String,
+)
+
+// Reject (permanent)
+reject_project(
+    env: Env,
+    verifier_address: Address,
+    project_id: String,
+    reason: String,             // stored on-chain for transparency
+)
+
+// Administrative hold
+suspend_project(
+    env: Env,
+    admin: Address,
+    project_id: String,
+    reason: String,
+)
+```
+
+### Data Stored On-Chain
+
+The `CarbonProject.status` field is updated in-place:
+
+| Outcome | `status` value |
+|---------|---------------|
+| Approved | `ProjectStatus::Verified` |
+| Rejected | `ProjectStatus::Rejected` |
+| Suspended | `ProjectStatus::Suspended` |
+
+The `reason` string for rejection/suspension is stored in the contract event log.
+
+### Data Stored Off-Chain
+
+| Store | Table / Object | Fields Updated |
+|-------|---------------|----------------|
+| PostgreSQL | `CarbonProject` | `status`, `updatedAt` |
+| PostgreSQL | `AuditLog` | actor, action, project_id, reason, timestamp |
+
+### Error Conditions
+
+| Error Code | Constant | Trigger |
+|-----------|----------|---------|
+| 1 | `ProjectNotFound` | `project_id` does not exist in contract storage |
+| 7 | `UnauthorizedVerifier` | Caller address is not in the `Verifiers` storage list |
+| 3 | `ProjectSuspended` | Attempting to verify a project that is already suspended |
+
+### Edge Cases
+
+- **Re-verification after rejection** is not possible — a rejected project must be re-registered with a new `project_id` and corrected documentation.
+- **Verifier rotation** — the verifier allow-list is managed by admin. If a verifier's accreditation lapses, admin removes them and the assigned projects must be re-assigned.
+- **Automated attestation** — `verification_listener.py` detects when a project has received a positive signal from a Gold Standard or Verra VCS API and can trigger `verify_project` automatically. Manual override is always available.
+
+---
+
+## Stage 3 — Oracle Monitoring
+
+**Summary:** The oracle service continuously collects real-world monitoring data (satellite imagery, methodology assessments) and posts it on-chain. This data is a prerequisite for minting — credits cannot be issued against stale monitoring data older than 365 days.
+
+### Actors Involved
+
+| Actor | Action |
+|-------|--------|
+| Oracle Service | `verification_listener.py` (6-hour poll), `satellite_monitor.py` (webhook receiver) |
+| Satellite Providers | Google Earth Engine sends webhook events with imagery; Planet Labs API provides independent validation |
+| Oracle Service | `price_oracle.py` posts benchmark prices every 12 hours |
+
+### Contracts Called
+
+**Contract:** `carbon_oracle`
+
+```rust
+// Submit monitoring data for a project period
+submit_monitoring_data(
+    env: Env,
+    oracle_signer: Address,
+    project_id: String,
+    period: String,            // e.g. "2024-Q1", "2024-H1", "2024"
+    tonnes_verified: i128,     // CO2e tonnes measured for this period
+    methodology_score: u32,    // recalculated per-period (0–100)
+    satellite_cid: String,     // IPFS CID of satellite imagery bundle
+    signature: BytesN<64>,     // Ed25519 signature over (project_id + period + nonce)
+    nonce: u64,                // monotonically increasing, prevents replay attacks
+)
+
+// Push benchmark price for a methodology + vintage combination
+update_credit_price(
+    env: Env,
+    oracle_signer: Address,
+    methodology: String,
+    vintage_year: u32,
+    price_usdc: i128,          // in stroops: 1 USDC = 10_000_000 stroops
+    signature: BytesN<64>,
+    nonce: u64,
+)
+
+// Flag a project for investigation (triggers suspension workflow)
+flag_project(
+    env: Env,
+    oracle_signer: Address,
+    project_id: String,
+    reason: String,
+    signature: BytesN<64>,
+    nonce: u64,
+)
+```
+
+### Data Stored On-Chain
+
+Stored in `carbon_oracle` contract storage:
+
+```rust
+// Key: MonitoringData(project_id, period)
+MonitoringData {
+    project_id: String,
+    period: String,
+    tonnes_verified: i128,
+    methodology_score: u32,
+    satellite_cid: String,
+    submitted_by: Address,
+    submitted_at: u64,       // ledger timestamp
+}
+
+// Key: LatestMonitoring(project_id) → period string (pointer to latest)
+// Key: BenchmarkPrice(methodology, vintage_year) → price in stroops
+// Key: OracleNonce → u64 (incremented per submission; prevents replay)
+```
+
+### Data Stored Off-Chain
+
+| Store | Table / Object | Fields |
+|-------|---------------|--------|
+| IPFS | Satellite imagery bundle | GeoTIFF files, biomass density maps, change detection overlays |
+| PostgreSQL | `MonitoringData` | projectId, period, tonnesVerified, methodologyScore, satelliteCid, submittedBy, submittedAt |
+| PostgreSQL | `OracleUpdate` | idempotencyKey, type (monitoring/price), txHash, status, attempts, lastError |
+
+### Error Conditions
+
+| Error Code | Constant | Trigger |
+|-----------|----------|---------|
+| 8 | `UnauthorizedOracle` | Caller is not the registered oracle signer |
+| 22 | `InvalidNonce` | Submitted nonce ≤ current stored nonce (replay attack prevention) |
+| 23 | `InvalidSignature` | Ed25519 signature verification fails |
+| 13 | `MonitoringDataStale` | `is_monitoring_current()` returns false — latest data is > 365 days old |
+
+### Edge Cases
+
+- **Monitoring freshness gate** — `is_monitoring_current(project_id)` is called by the credit contract during minting. If it returns false, minting is blocked regardless of other conditions.
+- **Nonce replay protection** — Each oracle submission must include a nonce strictly greater than the stored nonce. The oracle service reads the current nonce before each submission.
+- **Oracle key rotation** — `rotate_oracle(env, admin, new_oracle, new_pub_key)` allows replacing the oracle keypair without redeploying the contract. Old submissions remain valid under the historical nonce chain.
+- **Price deviation alert** — The oracle service checks the previous benchmark price before submitting. If the new price differs by more than 15%, it sends an alert to `ADMIN_ALERT_WEBHOOK` and waits for manual approval before posting.
+- **Multiple monitoring periods** — Each `(project_id, period)` pair is stored independently. The oracle stores a `LatestMonitoring` pointer for fast freshness checks during minting.
+
+---
+
+## Stage 4 — Credit Minting
+
+**Summary:** The project developer requests issuance of a credit batch corresponding to verified tonnes. The contract assigns globally unique serial numbers to every credit in the batch, preventing double-counting at the mathematical level.
+
+### Actors Involved
+
+| Actor | Action |
+|-------|--------|
+| Project Developer | Submits mint request via dashboard with the amount to issue |
+| Admin | Signs the `mint_credits` transaction |
+
+### Contract Called
+
+**Contract:** `carbon_credit`  
+**Function:** `mint_credits`
+
+```rust
+mint_credits(
+    env: Env,
+    admin: Address,
+    project_id: String,
+    amount: i128,              // tonnes to mint; max 1_000_000_000
+    vintage_year: u32,
+    batch_id: String,          // globally unique batch identifier
+    serial_start: u64,         // start of serial number range (inclusive)
+    serial_end: u64,           // end of serial number range (inclusive)
+    metadata_cid: String,      // IPFS CID for this batch's documentation
+    initial_owner: Address,    // project developer's Stellar address
+)
+```
+
+The contract calls `carbon_oracle.is_monitoring_current(project_id)` before minting and calls `verify_serial_range(serial_start, serial_end)` to check the `SerialRegistry` for collisions.
+
+### Data Stored On-Chain
+
+```rust
+// Key: Batch(batch_id)
+CreditBatch {
+    batch_id: String,
+    project_id: String,
+    vintage_year: u32,
+    amount: i128,
+    serial_start: u64,
+    serial_end: u64,
+    issued_at: u64,
+    status: CreditStatus::Active,
+    metadata_cid: String,
+    owner: Address,
+}
+
+// Key: ProjectBatches(project_id) → Vec<String>  (appended)
+// Key: SerialRegistry → Vec<SerialRange>          (appended; checked on every mint)
+```
+
+**Event emitted:**
+```rust
+CreditMintedEvent {
+    batch_id, project_id, admin, amount,
+    vintage_year, serial_start, serial_end, timestamp
+}
+```
+
+### Data Stored Off-Chain
+
+| Store | Table / Object | Fields |
+|-------|---------------|--------|
+| PostgreSQL | `CreditBatch` | id, batchId, projectId, vintageYear, amount, serialStart, serialEnd, status, metadataCid, issuedAt |
+| IPFS | Batch documentation | Monitoring period reports, methodology calculation workbook, third-party audit reports |
+
+### Error Conditions
+
+| Error Code | Constant | Trigger |
+|-----------|----------|---------|
+| 2 | `ProjectNotVerified` | Project status is not `Verified` |
+| 3 | `ProjectSuspended` | Project is under suspension |
+| 6 | `SerialNumberConflict` | Proposed `[serial_start, serial_end]` overlaps any range in `SerialRegistry` |
+| 18 | `InvalidSerialRange` | `serial_start > serial_end` or range exceeds `amount` |
+| 16 | `ZeroAmountNotAllowed` | `amount` is 0 |
+| 13 | `MonitoringDataStale` | Oracle freshness check fails (> 365 days) |
+| 20 | `MethodologyScoreLow` | Methodology score in latest monitoring data is < 70 |
+
+### Edge Cases
+
+- **Serial number collision** — `verify_serial_range` scans the entire `SerialRegistry` before minting. This is the core anti-double-counting mechanism. The backend pre-computes the next available serial range by querying the highest `serial_end` across all existing batches.
+- **Batch size cap** — A single batch cannot exceed `MAX_BATCH_SIZE` (1,000,000,000 credits). Large projects split issuance across multiple batches.
+- **Partial issuance** — Developers can mint less than the total verified tonnes (e.g., issue in tranches). Each tranche is a separate batch with non-overlapping serial ranges.
+- **Registry increment** — `increment_issued(env, oracle_address, project_id, amount)` is called on `carbon_registry` after a successful mint to track `total_credits_issued` against `total_credits_retired`.
+
+---
+
+## Stage 5 — Marketplace Listing
+
+**Summary:** A credit owner (typically the project developer) makes some or all of a batch available for purchase at a specified price per tonne. Listings are public and browsable without a wallet.
+
+### Actors Involved
+
+| Actor | Action |
+|-------|--------|
+| Credit Owner (Project Developer) | Creates a listing specifying amount and price |
+| Oracle Service | `price_oracle.py` posts benchmark prices to `carbon_oracle` for reference |
+
+### Contract Called
+
+**Contract:** `carbon_marketplace`  
+**Function:** `list_credits`
+
+```rust
+list_credits(
+    env: Env,
+    seller: Address,
+    listing_id: String,
+    batch_id: String,
+    project_id: String,
+    amount: i128,
+    price_per_credit_usdc: i128,   // in stroops (1 USDC = 10_000_000)
+    vintage_year: u32,
+    methodology: String,
+    country: String,
+)
+```
+
+Sellers can remove an unsold listing with:
+
+```rust
+delist_credits(
+    env: Env,
+    seller: Address,
+    listing_id: String,
+)
+```
+
+### Data Stored On-Chain
+
+```rust
+// Key: Listing(listing_id)
+MarketListing {
+    listing_id: String,
+    seller: Address,
+    batch_id: String,
+    project_id: String,
+    amount_available: i128,
+    price_per_credit: i128,     // stroops
+    vintage_year: u32,
+    methodology: String,
+    country: String,
+    created_at: u64,
+    status: ListingStatus::Active,
+}
+
+// Key: AllListings → Vec<String>  (appended)
+```
+
+**Event emitted:**
+```rust
+ListingCreatedEvent {
+    listing_id, seller, batch_id, amount, price_per_credit, timestamp
+}
+```
+
+### Data Stored Off-Chain
+
+| Store | Table / Object | Fields |
+|-------|---------------|--------|
+| PostgreSQL | `MarketListing` | id, listingId, projectId, batchId, seller, amountAvailable, pricePerCredit, vintageYear, methodology, country, status, createdAt |
+
+### Error Conditions
+
+| Error Code | Constant | Trigger |
+|-----------|----------|---------|
+| 3 | `ProjectSuspended` | The project associated with the batch has been suspended |
+| 4 | `InsufficientCredits` | Seller does not own enough credits in the specified batch |
+| 16 | `ZeroAmountNotAllowed` | Listing `amount` is 0 |
+| 12 | `PriceNotSet` | No oracle benchmark price exists for this methodology + vintage (warning; listing can still proceed) |
+
+### Edge Cases
+
+- **Partial listings** — An owner can list a fraction of a batch. The remaining credits stay with the owner until listed or transferred.
+- **Re-listing** — A seller can create multiple listings for the same batch as long as the total listed amount does not exceed their ownership.
+- **Suspended project delisting** — If a project is suspended after listing, `suspend_project(env, admin, project_id)` on the marketplace prevents new purchases against those listings. Existing sellers can still delist to recover their credits.
+- **Price discovery** — The frontend displays the oracle benchmark price alongside the seller's ask price to help buyers assess fair value.
+
+---
+
+## Stage 6 — Purchase
+
+**Summary:** A corporation buys credits from one or more listings. USDC is transferred from buyer to seller atomically in the same transaction as the credit transfer. A 1% protocol fee goes to the treasury.
+
+### Actors Involved
+
+| Actor | Action |
+|-------|--------|
+| Corporation (Buyer) | Selects listings, approves USDC spend, submits purchase transaction |
+
+### Contracts Called
+
+**Contract:** `carbon_marketplace`
+
+```rust
+// Single listing purchase
+purchase_credits(
+    env: Env,
+    buyer: Address,
+    listing_id: String,
+    amount: i128,
+)
+
+// Multi-project bulk purchase (one transaction)
+bulk_purchase(
+    env: Env,
+    buyer: Address,
+    listing_ids: Vec<String>,   // max 10 listings per transaction
+    amounts: Vec<i128>,         // parallel array; must match listing_ids length
+)
+```
+
+Internally, `purchase_credits` calls `carbon_credit.transfer_credits(seller, buyer, batch_id, amount)` and the USDC token contract to move payment.
+
+### Data Stored On-Chain
+
+The `MarketListing.amount_available` and `MarketListing.status` fields are updated:
+
+| Condition | New `status` |
+|-----------|-------------|
+| All available credits purchased | `ListingStatus::Sold` |
+| Partial purchase | `ListingStatus::PartiallyFilled` |
+
+Credit ownership in `carbon_credit` is updated: `CreditBatch.owner` changes from seller to buyer for the purchased amount (partial ownership tracked off-chain; on-chain only tracks full batch ownership).
+
+**Event emitted:**
+```rust
+PurchaseCompletedEvent {
+    listing_id, buyer, seller, amount, total_cost, timestamp
+}
+```
+
+### Data Stored Off-Chain
+
+| Store | Table / Object | Fields Updated |
+|-------|---------------|----------------|
+| PostgreSQL | `MarketListing` | `amountAvailable`, `status`, `updatedAt` |
+| PostgreSQL | `PurchaseRecord` | buyer, listingId, amount, totalCost, txHash, purchasedAt |
+
+### Error Conditions
+
+| Error Code | Constant | Trigger |
+|-----------|----------|---------|
+| 10 | `ListingNotFound` | `listing_id` does not exist or has been delisted |
+| 11 | `InsufficientLiquidity` | Requested `amount` exceeds `amount_available` on the listing |
+| 3 | `ProjectSuspended` | The project was suspended after the listing was created |
+| 4 | `InsufficientCredits` | Seller no longer owns the credits (e.g., transferred out of band) |
+
+### Edge Cases
+
+- **Bulk purchase limit** — `bulk_purchase` accepts a maximum of `MAX_BATCH_SIZE` (10) listings per transaction to stay within Soroban transaction size limits.
+- **Atomic execution** — The entire purchase (USDC transfer + credit transfer + listing update) is a single Soroban transaction. If any step fails, the whole transaction reverts.
+- **Protocol fee** — 1% of the purchase amount in USDC is sent to the `Treasury` address configured in `carbon_marketplace`. The seller receives 99% of `amount × price_per_credit`.
+- **Cart flow** — The frontend accumulates listings into a BulkPurchaseCart and batches them into groups of ≤10 for submission. Multiple transactions are submitted sequentially if the cart exceeds 10 listings.
+
+---
+
+## Stage 7 — Retirement
+
+**Summary:** A corporation permanently removes credits from circulation, claiming the carbon offset. Retirement is cryptographically irreversible — no admin key can reverse it. The retired credits are burned on-chain with a permanent record of who retired them, on whose behalf, and why.
+
+### Actors Involved
+
+| Actor | Action |
+|-------|--------|
+| Corporation (Credit Owner) | Initiates retirement specifying beneficiary and reason |
+| Backend | Generates certificate PDF and pins it to IPFS before the on-chain transaction |
+
+### Contract Called
+
+**Contract:** `carbon_credit`  
+**Function:** `retire_credits`
+
+```rust
+retire_credits(
+    env: Env,
+    holder: Address,
+    batch_id: String,
+    amount: i128,
+    retirement_id: String,       // globally unique; generated by backend
+    beneficiary: String,         // legal entity name (e.g. "Acme Corp")
+    reason: String,              // e.g. "2024 Scope 3 emissions offset"
+    certificate_cid: String,     // IPFS CID of PDF certificate (pre-generated)
+)
+```
+
+**This call is permanently irreversible. There is no `unretire_credits` function.**
+
+### Data Stored On-Chain
+
+```rust
+// Key: Retirement(retirement_id)
+RetirementCertificate {
+    retirement_id: String,
+    credit_batch_id: String,
+    project_id: String,
+    amount: i128,
+    retired_by: Address,
+    beneficiary: String,
+    retirement_reason: String,
+    vintage_year: u32,
+    serial_numbers: Vec<u64>,    // exact serials consumed
+    retired_at: u64,
+    tx_hash: String,
+    certificate_cid: String,     // IPFS pointer to PDF
+}
+```
+
+`CreditBatch.status` is updated:
+
+| Condition | New `status` |
+|-----------|-------------|
+| All credits in batch retired | `CreditStatus::FullyRetired` |
+| Some credits retired | `CreditStatus::PartiallyRetired` |
+
+**Event emitted:**
+```rust
+CreditRetiredEvent {
+    retirement_id, batch_id, project_id, amount,
+    retired_by, beneficiary, timestamp
+}
+```
+
+### Data Stored Off-Chain
+
+| Store | Table / Object | Fields |
+|-------|---------------|--------|
+| PostgreSQL | `RetirementRecord` | id, retirementId, batchId, projectId, amount, vintageYear, retiredBy, beneficiary, retirementReason, serialStart, serialEnd, serialNumbers, txHash, certificateCid, isValid, retiredAt |
+| IPFS | Retirement certificate PDF | Project name, methodology, vintage year, amount, serial numbers, beneficiary, reason, transaction hash, QR code, CarbonLedger branding |
+
+### Error Conditions
+
+| Error Code | Constant | Trigger |
+|-----------|----------|---------|
+| 4 | `InsufficientCredits` | Holder does not own enough credits in the batch |
+| 5 | `AlreadyRetired` | The batch is already `FullyRetired` |
+| 15 | `RetirementIrreversible` | Attempted reversal of an existing retirement record (guard clause) |
+| 16 | `ZeroAmountNotAllowed` | `amount` is 0 |
+| 3 | `ProjectSuspended` | Project is suspended; retirement is still permitted but flagged |
+
+### Edge Cases
+
+- **Certificate-first flow** — The backend generates and pins the PDF certificate to IPFS _before_ calling `retire_credits`, so the `certificate_cid` is embedded in the immutable on-chain record at the moment of retirement.
+- **Partial retirement** — A holder can retire part of a batch and keep the rest. Each partial retirement creates a new `RetirementCertificate` with its specific serial number range.
+- **Suspended project retirement** — Credits from a suspended project can still be retired. The certificate notes the project's suspension status. New purchases are blocked; retirement is not.
+- **Duplicate retirement_id** — The backend generates UUIDs for `retirement_id`. If the same UUID is submitted twice, the second call returns `AlreadyRetired`.
+- **Serial number traceability** — The `serial_numbers` array in `RetirementCertificate` contains the exact range of serial numbers retired. Anyone can look up a serial number in the audit explorer and trace it back to the original project, batch, and eventual retirement.
+
+---
+
+## Stage 8 — Certification
+
+**Summary:** A permanent, publicly verifiable certificate is generated and made available at a stable URL. No wallet is required to view or verify it. The certificate is the final artefact that a corporation includes in ESG disclosures, regulatory filings, or sustainability reports.
+
+### Actors Involved
+
+| Actor | Action |
+|-------|--------|
+| Backend | Generates PDF, pins to IPFS, stores public URL in database |
+| IPFS (Pinata) | Pins certificate for permanence |
+| Public / Auditor | Verifies certificate via public URL or QR code scan |
+
+### Contract Called (Read-Only)
+
+**Contract:** `carbon_credit`  
+**Function:** `get_retirement_certificate`
+
+```rust
+get_retirement_certificate(
+    env: Env,
+    retirement_id: String,
+) -> RetirementCertificate
+```
+
+This is a read-only query used by the verification page to display on-chain data alongside the PDF.
+
+### Data Stored On-Chain
+
+The `RetirementCertificate` stored in Stage 7 is immutable and permanent. No new data is written in Stage 8.
+
+### Data Stored Off-Chain
+
+| Store | Object | Contents |
+|-------|--------|----------|
+| IPFS | Certificate PDF | All retirement details, QR code pointing to public verification URL, CarbonLedger signature |
+| PostgreSQL | `RetirementRecord.certificateCid` | IPFS CID for permanent retrieval |
+
+### Certificate Contents
+
+| Field | Source |
+|-------|--------|
+| Retirement ID | Generated by backend (UUID) |
+| Transaction hash | Stellar ledger |
+| Credits retired (amount + serial numbers) | `RetirementCertificate.serial_numbers` |
+| Beneficiary | Submitted by retiring corporation |
+| Retirement reason | Submitted by retiring corporation |
+| Project name and methodology | `CarbonProject` in registry |
+| Vintage year | `CreditBatch.vintage_year` |
+| Country of origin | `CarbonProject.country` |
+| Retirement date | `RetirementCertificate.retired_at` |
+| QR code | Links to `https://app.carbonledger.com/retire/[retirement_id]` |
+| IPFS CID | For decentralised permanent access |
+
+### Public Verification
+
+Anyone can verify a retirement without a wallet:
+
+1. **URL** — `https://app.carbonledger.com/retire/[retirement_id]` renders the on-chain certificate and project details.
+2. **QR code** — Embossed on the PDF; resolves to the same public URL.
+3. **Serial number lookup** — `https://app.carbonledger.com/audit` accepts a serial number and returns the full provenance chain: minting batch → listing → purchase → retirement.
+4. **Bulk export** — `GET /api/v1/retirements/export/csv` returns all retirements for an authenticated corporation in CSV format for ESG report integration.
+
+### Edge Cases
+
+- **IPFS pinning failure** — If Pinata fails to pin the certificate, the retirement transaction is not submitted. The backend retries pinning via the BullMQ queue before proceeding.
+- **Certificate regeneration** — If the PDF needs to be re-generated (e.g., branded update), the new PDF gets a new CID. The original on-chain `certificate_cid` is not changed; both CIDs resolve to valid certificates.
+- **Permanent URL guarantee** — The public verification URL is keyed on `retirement_id`, which is immutable once the retirement transaction is confirmed. The URL will remain valid indefinitely.
+
+---
+
+## Error Reference
+
+Complete table of `CarbonError` codes used across all contracts:
+
+| Code | Constant | Contract(s) | Meaning |
+|------|----------|------------|---------|
+| 1 | `ProjectNotFound` | registry, marketplace | `project_id` not found in storage |
+| 2 | `ProjectNotVerified` | credit | Project status is not `Verified` |
+| 3 | `ProjectSuspended` | registry, credit, marketplace | Project is `Suspended`; issuance / listing blocked |
+| 4 | `InsufficientCredits` | credit, marketplace | Holder or seller does not own enough credits |
+| 5 | `AlreadyRetired` | credit | Batch is `FullyRetired` |
+| 6 | `SerialNumberConflict` | credit | Proposed serial range overlaps an existing one |
+| 7 | `UnauthorizedVerifier` | registry | Caller is not on the verifier allow-list |
+| 8 | `UnauthorizedOracle` | oracle | Caller is not the registered oracle signer |
+| 9 | `InvalidVintageYear` | credit | Vintage year is in the future or before 1990 |
+| 10 | `ListingNotFound` | marketplace | `listing_id` not found or delisted |
+| 11 | `InsufficientLiquidity` | marketplace | Requested amount > `amount_available` on listing |
+| 12 | `PriceNotSet` | marketplace | No oracle benchmark price for this methodology + vintage |
+| 13 | `MonitoringDataStale` | credit, oracle | Latest monitoring data is > 365 days old |
+| 14 | `DoubleCountingDetected` | credit | Reserved; raised if serial registry is inconsistent |
+| 15 | `RetirementIrreversible` | credit | Guard clause; retirement record cannot be reversed |
+| 16 | `ZeroAmountNotAllowed` | credit, marketplace | Amount parameter is 0 |
+| 17 | `ProjectAlreadyExists` | registry | `project_id` already registered |
+| 18 | `InvalidSerialRange` | credit | `serial_start > serial_end` or range does not match `amount` |
+| 19 | `AlreadyInitialized` | all | Contract `initialize()` called more than once |
+| 20 | `MethodologyScoreLow` | registry | Score < 70; project cannot advance to `Verified` |
+| 21 | `UnauthorizedUpgrade` | all | Caller is not `Admin` when calling `upgrade()` |
+| 22 | `InvalidNonce` | oracle | Nonce ≤ stored nonce; replay attack prevention |
+| 23 | `InvalidSignature` | oracle | Ed25519 signature verification failed |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,738 @@
+# Environment Variable Configuration Guide
+
+> Complete reference for every environment variable used by CarbonLedger — description, type, example value, whether it is required, and how to obtain it.
+
+---
+
+## Table of Contents
+
+- [Quick Setup](#quick-setup)
+- [Format Rules](#format-rules)
+- [Stellar Network](#stellar-network)
+- [Smart Contract Addresses](#smart-contract-addresses)
+- [Oracle Keypair](#oracle-keypair)
+- [Admin Keypair](#admin-keypair)
+- [Database](#database)
+- [Authentication](#authentication)
+- [IPFS / Pinata](#ipfs--pinata)
+- [Satellite Data](#satellite-data)
+- [Price Feeds](#price-feeds)
+- [Verifier APIs](#verifier-apis)
+- [Alerts](#alerts)
+- [Frontend (Next.js public variables)](#frontend-nextjs-public-variables)
+- [Redis](#redis)
+- [Backend](#backend)
+- [Oracle Service (Python — additional)](#oracle-service-python--additional)
+- [Production-Only Variables](#production-only-variables)
+
+---
+
+## Quick Setup
+
+```bash
+cp .env.example .env
+# Fill in required values, then verify:
+./scripts/verify-setup.sh
+```
+
+For a local development environment without external API access, only the **Required** variables marked below are needed. Optional and production-only variables can be left blank or at their defaults.
+
+---
+
+## Format Rules
+
+| Rule | Detail |
+|------|--------|
+| **Key format** | `SCREAMING_SNAKE_CASE`. No spaces around `=`. |
+| **Secret keys** | Stellar secret keys start with `S` and are 56 characters (e.g. `SABCDE...`). Never commit them. |
+| **Public keys** | Stellar public keys (G-addresses) start with `G` and are 56 characters. |
+| **Contract IDs** | Soroban contract IDs are 56-character StrKey strings starting with `C`. |
+| **USDC amounts** | All USDC values stored in the contracts use **stroops** (1 USDC = 10,000,000 stroops). Environment variables that represent USDC amounts follow the same convention unless noted. |
+| **URLs** | No trailing slash. Use `https://` for all external services. |
+| **Booleans** | Use `true` or `false` (lowercase). |
+| **Duration strings** | JWT expiry uses the `ms` library format: `7d`, `1h`, `30m`. |
+| **Quoted values** | Values containing spaces (e.g. `NETWORK_PASSPHRASE`) must be quoted in the `.env` file: `NETWORK_PASSPHRASE="Test SDF Network ; September 2015"`. |
+| **Frontend prefix** | All variables consumed by Next.js client-side code must be prefixed `NEXT_PUBLIC_`. Variables without this prefix are server-side only. |
+
+---
+
+## Stellar Network
+
+Variables that point to Stellar infrastructure endpoints.
+
+### `STELLAR_NETWORK`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Selects the Stellar network. Controls which default RPC and Horizon endpoints the oracle and backend use. |
+| **Type** | enum |
+| **Allowed values** | `testnet`, `mainnet` |
+| **Example** | `STELLAR_NETWORK=testnet` |
+| **Required** | Yes |
+| **How to obtain** | Set to `testnet` for local development. Change to `mainnet` for production. |
+
+---
+
+### `STELLAR_RPC_URL`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Soroban RPC endpoint. The backend and oracle use this to submit contract transactions and read contract state. |
+| **Type** | URL |
+| **Example** | `STELLAR_RPC_URL=https://soroban-testnet.stellar.org` |
+| **Required** | Yes |
+| **How to obtain** | **Testnet:** use `https://soroban-testnet.stellar.org` (public SDF endpoint, no API key required). **Mainnet:** use `https://soroban-mainnet.stellar.org` or a private RPC from [Quicknode](https://www.quicknode.com/chains/stellar), [Ankr](https://www.ankr.com/), or self-hosted. For high-throughput production workloads, the public endpoint has rate limits — use a dedicated provider. |
+
+---
+
+### `STELLAR_HORIZON_URL`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Stellar Horizon REST API endpoint. Used by the backend indexer to stream ledger events and by the frontend for account queries. |
+| **Type** | URL |
+| **Example** | `STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org` |
+| **Required** | Yes |
+| **How to obtain** | **Testnet:** `https://horizon-testnet.stellar.org` (SDF public). **Mainnet:** `https://horizon.stellar.org` (SDF public) or a private Horizon instance. |
+
+---
+
+### `NETWORK_PASSPHRASE`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Stellar network passphrase. Included in every transaction hash — using the wrong passphrase causes transactions to fail silently on the wrong network. |
+| **Type** | string (quoted) |
+| **Testnet example** | `NETWORK_PASSPHRASE="Test SDF Network ; September 2015"` |
+| **Mainnet example** | `NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"` |
+| **Required** | Yes |
+| **How to obtain** | These are fixed, well-known strings defined by the Stellar protocol. Copy from the examples above — do not modify. |
+
+---
+
+## Smart Contract Addresses
+
+Filled in after deploying the four Soroban contracts. See the [Contract Deployment section in the README](../README.md#-contract-deployment) for deployment commands.
+
+### `CARBON_REGISTRY_CONTRACT_ID`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Deployed address of the `carbon_registry` Soroban contract. |
+| **Type** | Soroban contract ID (56-char StrKey starting with `C`) |
+| **Example** | `CARBON_REGISTRY_CONTRACT_ID=CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4` |
+| **Required** | Yes |
+| **How to obtain** | Returned by `stellar contract deploy` when you deploy `carbon_registry.wasm`. |
+
+---
+
+### `CARBON_CREDIT_CONTRACT_ID`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Deployed address of the `carbon_credit` Soroban contract. |
+| **Type** | Soroban contract ID |
+| **Example** | `CARBON_CREDIT_CONTRACT_ID=CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBSC4` |
+| **Required** | Yes |
+| **How to obtain** | Returned by `stellar contract deploy` when you deploy `carbon_credit.wasm`. |
+
+---
+
+### `CARBON_MARKETPLACE_CONTRACT_ID`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Deployed address of the `carbon_marketplace` Soroban contract. |
+| **Type** | Soroban contract ID |
+| **Example** | `CARBON_MARKETPLACE_CONTRACT_ID=CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCSC4` |
+| **Required** | Yes |
+| **How to obtain** | Returned by `stellar contract deploy` when you deploy `carbon_marketplace.wasm`. |
+
+---
+
+### `CARBON_ORACLE_CONTRACT_ID`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Deployed address of the `carbon_oracle` Soroban contract. |
+| **Type** | Soroban contract ID |
+| **Example** | `CARBON_ORACLE_CONTRACT_ID=CDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDSC4` |
+| **Required** | Yes |
+| **How to obtain** | Returned by `stellar contract deploy` when you deploy `carbon_oracle.wasm`. |
+
+---
+
+### `USDC_CONTRACT_ID`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Contract ID of the USDC token on Stellar. The marketplace uses this for payment settlement. |
+| **Type** | Soroban contract ID |
+| **Testnet example** | `USDC_CONTRACT_ID=CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA` |
+| **Required** | Yes |
+| **How to obtain** | **Testnet:** the testnet USDC contract ID is published in the [Stellar testnet asset list](https://developers.stellar.org/docs/tokens/usdc). **Mainnet:** the official Circle USDC contract ID is published at [centre.io](https://www.centre.io/usdc-stellar). |
+
+---
+
+## Oracle Keypair
+
+The oracle keypair is used by the Python oracle services to sign monitoring data before submitting it to the `carbon_oracle` contract. The contract stores the public key and verifies each submission's Ed25519 signature.
+
+### `ORACLE_SECRET_KEY`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Stellar secret key used by oracle services to sign contract transactions. Must match the public key registered in the oracle contract via `initialize()`. |
+| **Type** | Stellar secret key (56-char string starting with `S`) |
+| **Example** | `ORACLE_SECRET_KEY=SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` |
+| **Required** | Yes (oracle and backend services) |
+| **Security** | Never commit. Rotate via `carbon_oracle.rotate_oracle()` if compromised. See [docs/KEY_ROTATION_PROCEDURES.md](KEY_ROTATION_PROCEDURES.md). |
+| **How to obtain** | Generate with `stellar keys generate --network testnet`. The corresponding public key is the `ORACLE_PUBLIC_KEY`. |
+
+---
+
+### `ORACLE_PUBLIC_KEY`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Stellar public key (G-address) of the oracle keypair. Stored in the oracle contract for signature verification. |
+| **Type** | Stellar public key (56-char string starting with `G`) |
+| **Example** | `ORACLE_PUBLIC_KEY=GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` |
+| **Required** | Yes |
+| **How to obtain** | Derived from `ORACLE_SECRET_KEY`. Run `stellar keys show <key-name>` or derive programmatically from the secret key using stellar-sdk. |
+
+---
+
+## Admin Keypair
+
+Used to deploy and initialize contracts and perform admin operations (verifier list management, oracle rotation, contract upgrades).
+
+### `ADMIN_SECRET_KEY`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Stellar secret key for the contract admin account. Authorized to call `initialize()`, `upgrade()`, and other admin functions on all four contracts. |
+| **Type** | Stellar secret key |
+| **Example** | `ADMIN_SECRET_KEY=SYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY` |
+| **Required** | Yes (deployment and admin operations) |
+| **Security** | Treat as a root credential. Use a hardware wallet or HSM in production. See [docs/secrets-management.md](secrets-management.md). |
+| **How to obtain** | Generate with `stellar keys generate --network testnet`. Fund the account with [friendbot](https://friendbot.stellar.org) on testnet. |
+
+---
+
+### `ADMIN_PUBLIC_KEY`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Stellar public key (G-address) of the admin account. |
+| **Type** | Stellar public key |
+| **Example** | `ADMIN_PUBLIC_KEY=GYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY` |
+| **Required** | Yes |
+| **How to obtain** | Derived from `ADMIN_SECRET_KEY`. |
+
+---
+
+## Database
+
+### `DATABASE_URL`
+
+| Property | Value |
+|----------|-------|
+| **Description** | PostgreSQL connection string used by Prisma ORM in the backend. |
+| **Type** | PostgreSQL connection URL |
+| **Format** | `postgresql://<user>:<password>@<host>:<port>/<database>` |
+| **Example** | `DATABASE_URL=postgresql://carbonledger:secret@localhost:5432/carbonledger` |
+| **Required** | Yes |
+| **How to obtain** | Create a local database: `createdb carbonledger`. Then set `<password>` to the value of `POSTGRES_PASSWORD`. For production, use a managed service (AWS RDS, Supabase, Neon). |
+
+---
+
+### `POSTGRES_PASSWORD`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Password for the `carbonledger` PostgreSQL user. Interpolated into `DATABASE_URL` by Docker Compose. |
+| **Type** | string |
+| **Example** | `POSTGRES_PASSWORD=changeme` |
+| **Required** | Yes (Docker Compose) |
+| **How to obtain** | Choose a strong random password. `openssl rand -base64 32` generates a suitable value. |
+
+---
+
+### `DB_POOL_MAX`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Maximum number of database connections Prisma keeps open simultaneously. |
+| **Type** | integer |
+| **Default** | `10` |
+| **Example** | `DB_POOL_MAX=10` |
+| **Required** | No |
+| **Rule of thumb** | `(num_cpu_cores × 2) + 1`, capped at `pg_max_connections / num_replicas`. |
+
+---
+
+### `DB_POOL_TIMEOUT_MS`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Milliseconds to wait for a free connection before Prisma throws `P2024` (connection pool timeout). |
+| **Type** | integer (milliseconds) |
+| **Default** | `10000` |
+| **Example** | `DB_POOL_TIMEOUT_MS=10000` |
+| **Required** | No |
+
+---
+
+### `DB_CONNECT_TIMEOUT_S`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Seconds to wait when opening a new TCP connection to PostgreSQL before timing out. |
+| **Type** | integer (seconds) |
+| **Default** | `10` |
+| **Example** | `DB_CONNECT_TIMEOUT_S=10` |
+| **Required** | No |
+
+---
+
+## Authentication
+
+### `JWT_SECRET`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Secret used to sign and verify JWT access tokens issued by the backend API. |
+| **Type** | string (min 32 characters recommended) |
+| **Example** | `JWT_SECRET=a-very-long-random-string-here` |
+| **Required** | Yes |
+| **How to obtain** | Generate with `openssl rand -hex 32`. Rotate by restarting the backend — all existing tokens immediately become invalid. |
+
+---
+
+### `JWT_EXPIRY`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Lifetime of access tokens issued by the backend. |
+| **Type** | duration string (`ms` library format) |
+| **Default** | `7d` |
+| **Example** | `JWT_EXPIRY=7d` |
+| **Required** | No |
+| **Allowed formats** | `7d` (7 days), `1h` (1 hour), `30m` (30 minutes), `86400000` (ms integer) |
+
+---
+
+## IPFS / Pinata
+
+Project documentation, satellite imagery, and retirement certificates are stored on IPFS. CarbonLedger uses [Pinata](https://pinata.cloud) as the pinning service.
+
+### `IPFS_API_URL`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Base URL of the IPFS pinning API. |
+| **Type** | URL |
+| **Default** | `https://api.pinata.cloud` |
+| **Example** | `IPFS_API_URL=https://api.pinata.cloud` |
+| **Required** | Yes |
+| **How to obtain** | Use the default Pinata URL. If self-hosting IPFS, replace with your node's API URL. |
+
+---
+
+### `IPFS_API_KEY`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Pinata API key for authenticating upload and pin requests. |
+| **Type** | string |
+| **Example** | `IPFS_API_KEY=abc123def456` |
+| **Required** | Yes |
+| **How to obtain** | Sign up at [pinata.cloud](https://pinata.cloud), go to **API Keys** → **New Key**. Grant `pinFileToIPFS` and `pinJSONToIPFS` permissions. |
+
+---
+
+### `IPFS_SECRET_KEY`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Pinata secret API key paired with `IPFS_API_KEY`. |
+| **Type** | string |
+| **Example** | `IPFS_SECRET_KEY=xyz789...` |
+| **Required** | Yes |
+| **How to obtain** | Shown once at API key creation time on the Pinata dashboard. Store it immediately. |
+
+---
+
+## Satellite Data
+
+Used by the oracle service (`satellite_monitor.py`) to receive and validate satellite monitoring data.
+
+### `GOOGLE_EARTH_ENGINE_KEY`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Service account key for authenticating with the Google Earth Engine API. Used to pull biomass density and land-cover change data for project areas. |
+| **Type** | JSON string or path to a JSON key file |
+| **Example** | `GOOGLE_EARTH_ENGINE_KEY=/etc/carbonledger/gee-service-account.json` |
+| **Required** | Yes (oracle monitoring) |
+| **How to obtain** | 1. Create a GCP project. 2. Enable the **Earth Engine API**. 3. Create a **service account** and grant it the `Earth Engine Resource Writer` role. 4. Download the JSON key file. 5. Register the service account email at [code.earthengine.google.com](https://code.earthengine.google.com) (requires approval). |
+
+---
+
+### `PLANET_LABS_API_KEY`
+
+| Property | Value |
+|----------|-------|
+| **Description** | API key for Planet Labs satellite imagery (secondary validation source). |
+| **Type** | string |
+| **Example** | `PLANET_LABS_API_KEY=pl.XXXXXXXXX` |
+| **Required** | No (GEE is the primary source; Planet Labs is optional supplementary data) |
+| **How to obtain** | Register at [planet.com](https://www.planet.com/explorer/) and request API access under the **Education & Research** or **Commercial** tier. |
+
+---
+
+### `GEE_WEBHOOK_SECRET`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Shared secret used to verify the HMAC-SHA256 signature on incoming Google Earth Engine webhook events received by `satellite_monitor.py`. |
+| **Type** | string (min 32 characters) |
+| **Example** | `GEE_WEBHOOK_SECRET=webhook-secret-32-chars-minimum` |
+| **Required** | Yes (if using GEE webhook mode) |
+| **How to obtain** | Generate with `openssl rand -hex 32`. Configure the same value in your GEE webhook endpoint configuration. |
+
+---
+
+## Price Feeds
+
+The oracle service (`price_oracle.py`) fetches carbon credit benchmark prices from market data providers every 12 hours and posts them to the `carbon_oracle` contract.
+
+### `XPANSIV_API_KEY`
+
+| Property | Value |
+|----------|-------|
+| **Description** | API key for the Xpansiv CBL (Carbon, Biodiversity, and Land) marketplace — the primary carbon credit price data source. |
+| **Type** | string |
+| **Example** | `XPANSIV_API_KEY=xpansiv_live_...` |
+| **Required** | Yes (price feed) |
+| **How to obtain** | Contact [Xpansiv](https://xpansiv.com/cbl) to request API access. This requires a commercial relationship or institutional access. Sandbox keys are available for development. |
+
+---
+
+### `TOUCAN_API_KEY`
+
+| Property | Value |
+|----------|-------|
+| **Description** | API key for Toucan Protocol — used as a secondary price reference for on-chain carbon credit prices. |
+| **Type** | string |
+| **Example** | `TOUCAN_API_KEY=toucan_...` |
+| **Required** | No (supplementary to Xpansiv) |
+| **How to obtain** | Register at [toucan.earth](https://toucan.earth) and request API access. |
+
+---
+
+## Verifier APIs
+
+Used by `verification_listener.py` to poll external carbon registry APIs for project attestation signals.
+
+### `GOLD_STANDARD_API_URL`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Base URL of the Gold Standard Foundation public registry API. |
+| **Type** | URL |
+| **Example** | `GOLD_STANDARD_API_URL=https://registry.goldstandard.org/api` |
+| **Required** | Yes (if Gold Standard projects are registered) |
+| **How to obtain** | Published in the [Gold Standard API documentation](https://goldstandard.org/resources). Contact registry@goldstandard.org for API access credentials. |
+
+---
+
+### `GOLD_STANDARD_API_KEY`
+
+| Property | Value |
+|----------|-------|
+| **Description** | API key for authenticating with the Gold Standard registry API. |
+| **Type** | string |
+| **Example** | `GOLD_STANDARD_API_KEY=gs_...` |
+| **Required** | Yes (if Gold Standard projects are registered) |
+| **How to obtain** | Requested from the Gold Standard Foundation. Requires verifier accreditation. |
+
+---
+
+### `VERRA_VCS_API_URL`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Base URL of the Verra VCS (Verified Carbon Standard) registry API. |
+| **Type** | URL |
+| **Example** | `VERRA_VCS_API_URL=https://registry.verra.org/app/search/VCS` |
+| **Required** | Yes (if VCS projects are registered) |
+| **How to obtain** | Published in the [Verra registry documentation](https://verra.org/programs/verified-carbon-standard/). |
+
+---
+
+### `VERRA_VCS_API_KEY`
+
+| Property | Value |
+|----------|-------|
+| **Description** | API key for authenticating with the Verra VCS registry API. |
+| **Type** | string |
+| **Example** | `VERRA_VCS_API_KEY=verra_...` |
+| **Required** | Yes (if VCS projects are registered) |
+| **How to obtain** | Request from Verra. Requires verifier registration at [verra.org](https://verra.org). |
+
+---
+
+## Alerts
+
+### `ADMIN_ALERT_WEBHOOK`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Webhook URL that receives admin alerts — including oracle price deviation warnings (>15% single-update change) and project flagging events. |
+| **Type** | URL (HTTPS) |
+| **Example** | `ADMIN_ALERT_WEBHOOK=https://hooks.slack.com/services/T.../B.../...` |
+| **Required** | No (alerts are skipped if not set) |
+| **How to obtain** | Create an **Incoming Webhook** in your Slack workspace at `api.slack.com/apps`, or use any webhook endpoint (Discord, PagerDuty, custom). |
+
+---
+
+## Frontend (Next.js public variables)
+
+These variables are embedded in the browser bundle at build time. They must not contain secrets. All are prefixed `NEXT_PUBLIC_`.
+
+### `NEXT_PUBLIC_STELLAR_NETWORK`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Network name displayed in the UI and used to configure Freighter wallet. |
+| **Type** | enum |
+| **Allowed values** | `testnet`, `mainnet` |
+| **Example** | `NEXT_PUBLIC_STELLAR_NETWORK=testnet` |
+| **Required** | Yes |
+
+---
+
+### `NEXT_PUBLIC_HORIZON_URL`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Horizon API URL used by the frontend for account balance and transaction queries. |
+| **Type** | URL |
+| **Example** | `NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org` |
+| **Required** | Yes |
+
+---
+
+### `NEXT_PUBLIC_SOROBAN_RPC_URL`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Soroban RPC URL the frontend uses for direct contract reads (e.g. browsing listings, looking up certificates without signing). |
+| **Type** | URL |
+| **Example** | `NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org` |
+| **Required** | Yes |
+
+---
+
+### `NEXT_PUBLIC_API_URL`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Base URL of the CarbonLedger backend REST API. Used by all frontend API calls. |
+| **Type** | URL |
+| **Example** | `NEXT_PUBLIC_API_URL=http://localhost:3001/api/v1` |
+| **Required** | Yes |
+
+---
+
+### `NEXT_PUBLIC_REGISTRY_CONTRACT`
+
+| Property | Value |
+|----------|-------|
+| **Description** | `carbon_registry` contract ID (mirrors `CARBON_REGISTRY_CONTRACT_ID` for browser use). |
+| **Type** | Soroban contract ID |
+| **Example** | `NEXT_PUBLIC_REGISTRY_CONTRACT=CA...` |
+| **Required** | Yes |
+
+---
+
+### `NEXT_PUBLIC_CREDIT_CONTRACT`
+
+| Property | Value |
+|----------|-------|
+| **Description** | `carbon_credit` contract ID for browser use. |
+| **Type** | Soroban contract ID |
+| **Example** | `NEXT_PUBLIC_CREDIT_CONTRACT=CB...` |
+| **Required** | Yes |
+
+---
+
+### `NEXT_PUBLIC_MARKETPLACE_CONTRACT`
+
+| Property | Value |
+|----------|-------|
+| **Description** | `carbon_marketplace` contract ID for browser use. |
+| **Type** | Soroban contract ID |
+| **Example** | `NEXT_PUBLIC_MARKETPLACE_CONTRACT=CC...` |
+| **Required** | Yes |
+
+---
+
+### `NEXT_PUBLIC_ORACLE_CONTRACT`
+
+| Property | Value |
+|----------|-------|
+| **Description** | `carbon_oracle` contract ID for browser use (used by the Oracle Status component). |
+| **Type** | Soroban contract ID |
+| **Example** | `NEXT_PUBLIC_ORACLE_CONTRACT=CD...` |
+| **Required** | Yes |
+
+---
+
+### `NEXT_PUBLIC_USDC_CONTRACT`
+
+| Property | Value |
+|----------|-------|
+| **Description** | USDC token contract ID for browser use. |
+| **Type** | Soroban contract ID |
+| **Example** | `NEXT_PUBLIC_USDC_CONTRACT=CBIELTK6...` |
+| **Required** | Yes |
+
+---
+
+## Redis
+
+Redis is used by the backend's BullMQ job queue for certificate generation, IPFS pinning retries, and oracle update jobs.
+
+### `REDIS_HOST`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Hostname or IP address of the Redis server. |
+| **Type** | string |
+| **Default** | `localhost` |
+| **Example** | `REDIS_HOST=localhost` |
+| **Required** | Yes |
+
+---
+
+### `REDIS_PORT`
+
+| Property | Value |
+|----------|-------|
+| **Description** | TCP port Redis listens on. |
+| **Type** | integer |
+| **Default** | `6379` |
+| **Example** | `REDIS_PORT=6379` |
+| **Required** | Yes |
+
+---
+
+### `REDIS_PASSWORD`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Redis authentication password. Leave blank if Redis is running without auth (local dev only). |
+| **Type** | string |
+| **Example** | `REDIS_PASSWORD=redis-secret` |
+| **Required** | No (local dev) / Yes (production) |
+| **How to obtain** | Set in your Redis configuration (`requirepass` directive) or via your managed Redis provider (Upstash, AWS ElastiCache, Redis Cloud). |
+
+---
+
+## Backend
+
+### `PORT`
+
+| Property | Value |
+|----------|-------|
+| **Description** | TCP port the NestJS backend API listens on. |
+| **Type** | integer |
+| **Default** | `3001` |
+| **Example** | `PORT=3001` |
+| **Required** | No |
+
+---
+
+### `FRONTEND_URL`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Origin URL of the Next.js frontend. Used in CORS configuration and email links. |
+| **Type** | URL |
+| **Default** | `http://localhost:3000` |
+| **Example** | `FRONTEND_URL=http://localhost:3000` |
+| **Required** | Yes |
+
+---
+
+### `ALLOWED_ORIGINS`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Comma-separated list of origins allowed by the CORS policy. The backend rejects requests from any origin not in this list. |
+| **Type** | comma-separated URLs |
+| **Example** | `ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001,https://app.carbonledger.com` |
+| **Required** | Yes |
+
+---
+
+### `BODY_SIZE_LIMIT`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Maximum allowed size of JSON request bodies. Uses the `express body-parser` size format. |
+| **Type** | size string |
+| **Default** | `10kb` |
+| **Example** | `BODY_SIZE_LIMIT=10kb` |
+| **Required** | No |
+| **Allowed formats** | `10kb`, `1mb`, `500b`, or a byte integer like `10240`. |
+
+---
+
+## Oracle Service (Python — additional)
+
+The Python oracle services (`verification_listener.py`, `price_oracle.py`, `satellite_monitor.py`) read some additional variables not listed in `.env.example`. Set these in the same `.env` file or as system environment variables.
+
+### `BACKEND_API_URL`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Base URL of the CarbonLedger backend API. The oracle service posts monitoring results to the backend indexer. |
+| **Type** | URL |
+| **Example** | `BACKEND_API_URL=http://localhost:3001/api/v1` |
+| **Required** | Yes (oracle services) |
+
+---
+
+### `BACKEND_JWT_TOKEN`
+
+| Property | Value |
+|----------|-------|
+| **Description** | Pre-issued JWT token for the oracle service account. The oracle uses this to authenticate against the backend API when reporting monitoring results. |
+| **Type** | JWT string |
+| **Example** | `BACKEND_JWT_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...` |
+| **Required** | Yes (oracle services) |
+| **How to obtain** | Issue a long-lived service token from the backend using an admin account, or configure a dedicated oracle user and generate a token via `POST /api/v1/auth/login`. |
+
+---
+
+## Production-Only Variables
+
+These variables are not in `.env.example` because they are not needed for local development. Configure them for staging and production deployments.
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `NODE_ENV` | Node.js environment mode. Set to `production` to disable debug logging and enable performance optimisations. | `NODE_ENV=production` |
+| `LOG_LEVEL` | Minimum log level for the backend (`error`, `warn`, `info`, `debug`, `verbose`). | `LOG_LEVEL=info` |
+| `JWT_REFRESH_SECRET` | Separate secret for signing refresh tokens. Must differ from `JWT_SECRET`. | `JWT_REFRESH_SECRET=...` |
+| `JWT_REFRESH_EXPIRY` | Lifetime of refresh tokens. | `JWT_REFRESH_EXPIRY=30d` |
+| `AWS_REGION` | AWS region for CloudWatch log delivery. | `AWS_REGION=us-east-1` |
+| `AWS_CLOUDWATCH_GROUP` | CloudWatch log group name for structured backend logs. | `AWS_CLOUDWATCH_GROUP=/carbonledger/backend` |
+| `EMAIL_FROM` | Sender address used for outbound emails (retirement certificate delivery, alerts). | `EMAIL_FROM=noreply@carbonledger.com` |
+| `REDIS_SENTINELS` | Comma-separated `host:port` pairs for Redis Sentinel failover configuration. | `REDIS_SENTINELS=sentinel1:26379,sentinel2:26379` |
+| `REDIS_SENTINEL_NAME` | Name of the Redis master in Sentinel configuration. | `REDIS_SENTINEL_NAME=mymaster` |
+| `NEXT_PUBLIC_NETWORK_PASSPHRASE` | Network passphrase exposed to browser for Freighter wallet configuration. | `NEXT_PUBLIC_NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"` |
+| `NEXT_PUBLIC_APP_URL` | Canonical public URL of the app. Used for generating QR code links in certificates. | `NEXT_PUBLIC_APP_URL=https://app.carbonledger.com` |


### PR DESCRIPTION
## Summary

- Adds `docs/carbon-credit-lifecycle.md` — a full per-stage breakdown of all 8 lifecycle stages (registration → verification → monitoring → minting → listing → purchase → retirement → certification), covering actors, Soroban contract function signatures, on-chain data structures, off-chain storage (PostgreSQL + IPFS), error conditions with codes, edge cases, and a Mermaid sequence diagram
- Adds `docs/configuration.md` — every environment variable documented with description, type, example value, required status, and step-by-step instructions for obtaining each value (Stellar RPC URLs, contract IDs, Pinata, Google Earth Engine, Xpansiv, Verra, Gold Standard, etc.)
- Updates `README.md` to link both new docs from the New Contributors section and inline after the Credit Lifecycle diagram
- Updates `.env.example` to add `BACKEND_API_URL` and `BACKEND_JWT_TOKEN` (oracle service variables) so the file stays in sync with the configuration guide

## Test plan

- [ ] Open `docs/carbon-credit-lifecycle.md` on GitHub and confirm the Mermaid sequence diagram renders correctly
- [ ] Confirm all 8 lifecycle stages are present with actors, contract functions, on-chain data, off-chain data, error conditions, and edge cases
- [ ] Open `docs/configuration.md` and verify every variable in `.env.example` has a corresponding entry
- [ ] Confirm the two new links in `README.md` resolve to the correct files
- [ ] Check `.env.example` includes `BACKEND_API_URL` and `BACKEND_JWT_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)