### PR TITLE
feat: add tooltips to oracle freshness indicators

### DIFF
--- a/frontend/components/OracleStatus.tsx
+++ b/frontend/components/OracleStatus.tsx
@@ -2,12 +2,19 @@
 
 import { useOracleHealth, OracleHealth } from "../lib/admin-api";
 import { colors, typography, spacing, borderRadius, shadows } from "../styles/design-system";
+import Tooltip from "./Tooltip";
 
 // Spec thresholds
 const AMBER_DAYS = 300;
 const RED_DAYS   = 365;
 
 type Status = "green" | "amber" | "red";
+
+const TOOLTIP_TEXT: Record<Status, string> = {
+  green: "Healthy — monitoring data is within the last 365 days.\nNew credit issuance is not affected.",
+  amber: "Warning — monitoring data is approaching the 365-day limit.\nIssuance may be blocked soon if data is not refreshed.",
+  red:   "Stale — monitoring data is older than 365 days.\nNew credit issuance is blocked until fresh data is submitted.",
+};
 
 function getStatus(o: OracleHealth): Status {
   if (o.daysSinceUpdate >= RED_DAYS)   return "red";
@@ -164,19 +171,22 @@ export default function OracleStatus() {
                   </p>
                 </div>
 
-                <span style={{
-                  fontFamily:   typography.fontFamily.sans,
-                  fontSize:     typography.fontSize.xs,
-                  fontWeight:   typography.fontWeight.medium,
-                  color:        st.text,
-                  background:   st.bg,
-                  border:       `1px solid ${st.border}`,
-                  padding:      `2px ${spacing[2]}`,
-                  borderRadius: borderRadius.full,
-                  whiteSpace:   "nowrap",
-                }}>
-                  {st.label}
-                </span>
+                <Tooltip content={TOOLTIP_TEXT[status]}>
+                  <span style={{
+                    fontFamily:   typography.fontFamily.sans,
+                    fontSize:     typography.fontSize.xs,
+                    fontWeight:   typography.fontWeight.medium,
+                    color:        st.text,
+                    background:   st.bg,
+                    border:       `1px solid ${st.border}`,
+                    padding:      `2px ${spacing[2]}`,
+                    borderRadius: borderRadius.full,
+                    whiteSpace:   "nowrap",
+                    cursor:       "default",
+                  }}>
+                    {st.label}
+                  </span>
+                </Tooltip>
               </li>
             );
           })}

--- a/frontend/components/ProjectOracleStatus.tsx
+++ b/frontend/components/ProjectOracleStatus.tsx
@@ -2,10 +2,14 @@
 
 import { useOracleStatus } from "../lib/api";
 import { colors } from "../styles/design-system";
+import Tooltip from "./Tooltip";
 
 interface ProjectOracleStatusProps {
   projectId: string;
 }
+
+const ACTIVE_TOOLTIP   = "Healthy — monitoring data is within the last 365 days.\nNew credit issuance is not affected.";
+const INACTIVE_TOOLTIP = "Offline — no oracle monitoring data available.\nNew credit issuance is blocked until data is submitted.";
 
 export default function ProjectOracleStatus({ projectId }: ProjectOracleStatusProps) {
   const { data: status, isLoading } = useOracleStatus(projectId);
@@ -23,27 +27,33 @@ export default function ProjectOracleStatus({ projectId }: ProjectOracleStatusPr
     return <p style={{ color: colors.neutral[500] }}>No oracle data available.</p>;
   }
 
-  const isCurrent = status.isCurrent;
-  const lastUpdate = status.lastSubmittedAt ? new Date(status.lastSubmittedAt).toLocaleDateString() : 'Never';
+  const isCurrent  = status.isCurrent;
+  const lastUpdate = status.lastSubmittedAt ? new Date(status.lastSubmittedAt).toLocaleDateString() : "Never";
+  const tooltip    = isCurrent ? ACTIVE_TOOLTIP : INACTIVE_TOOLTIP;
 
   return (
     <div>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.5rem' }}>
-        <div style={{
-          width: '8px',
-          height: '8px',
-          background: isCurrent ? colors.primary[500] : colors.neutral[400],
-          borderRadius: '50%'
-        }} />
-        <span style={{ fontSize: '0.875rem', color: colors.neutral[700] }}>
-          {isCurrent ? 'Active' : 'Inactive'}
-        </span>
+      <div style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginBottom: "0.5rem" }}>
+        <Tooltip content={tooltip}>
+          <span style={{ display: "inline-flex", alignItems: "center", gap: "0.4rem", cursor: "default" }}>
+            <span style={{
+              width: "8px",
+              height: "8px",
+              background: isCurrent ? colors.primary[500] : colors.neutral[400],
+              borderRadius: "50%",
+              display: "inline-block",
+            }} />
+            <span style={{ fontSize: "0.875rem", color: colors.neutral[700] }}>
+              {isCurrent ? "Active" : "Inactive"}
+            </span>
+          </span>
+        </Tooltip>
       </div>
-      <p style={{ fontSize: '0.75rem', color: colors.neutral[500], margin: 0 }}>
+      <p style={{ fontSize: "0.75rem", color: colors.neutral[500], margin: 0 }}>
         Last update: {lastUpdate}
       </p>
       {status.latestScore !== null && (
-        <p style={{ fontSize: '0.75rem', color: colors.neutral[500], margin: '0.25rem 0 0' }}>
+        <p style={{ fontSize: "0.75rem", color: colors.neutral[500], margin: "0.25rem 0 0" }}>
           Latest score: {status.latestScore}/100
         </p>
       )}

--- a/frontend/components/Tooltip.tsx
+++ b/frontend/components/Tooltip.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState, useRef, useEffect, useId } from "react";
+
+interface TooltipProps {
+  content: string;
+  children: React.ReactElement;
+}
+
+export default function Tooltip({ content, children }: TooltipProps) {
+  const [visible, setVisible] = useState(false);
+  const id = useId();
+  const containerRef = useRef<HTMLSpanElement>(null);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!visible) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setVisible(false);
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [visible]);
+
+  return (
+    <span
+      ref={containerRef}
+      style={{ position: "relative", display: "inline-flex", alignItems: "center" }}
+      onMouseEnter={() => setVisible(true)}
+      onMouseLeave={() => setVisible(false)}
+      onFocusCapture={() => setVisible(true)}
+      onBlurCapture={() => setVisible(false)}
+    >
+      {/* Clone child to add aria-describedby */}
+      {/* We wrap child in a focusable span for keyboard accessibility */}
+      <span
+        tabIndex={0}
+        aria-describedby={id}
+        style={{ display: "inline-flex", alignItems: "center", outline: "none" }}
+        onFocus={() => setVisible(true)}
+        onBlur={() => setVisible(false)}
+      >
+        {children}
+      </span>
+
+      {visible && (
+        <span
+          id={id}
+          role="tooltip"
+          style={{
+            position: "absolute",
+            bottom: "calc(100% + 8px)",
+            left: "50%",
+            transform: "translateX(-50%)",
+            background: "rgba(17,24,39,0.95)",
+            color: "#fff",
+            fontSize: "0.75rem",
+            lineHeight: 1.5,
+            padding: "0.5rem 0.75rem",
+            borderRadius: "0.375rem",
+            whiteSpace: "pre-line",
+            width: "220px",
+            zIndex: 50,
+            pointerEvents: "none",
+            boxShadow: "0 4px 12px rgba(0,0,0,0.25)",
+          }}
+        >
+          {content}
+          {/* Arrow */}
+          <span style={{
+            position: "absolute",
+            top: "100%",
+            left: "50%",
+            transform: "translateX(-50%)",
+            borderWidth: "5px",
+            borderStyle: "solid",
+            borderColor: "rgba(17,24,39,0.95) transparent transparent transparent",
+          }} />
+        </span>
+      )}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
Adds accessible tooltips to oracle freshness status badges in `OracleStatus` and `ProjectOracleStatus` components.

- New `Tooltip` component (keyboard accessible, Escape to dismiss, `role="tooltip"` + `aria-describedby`)
- Tooltip explains **Healthy** (data within 365 days), **Warning** (approaching 365 days), and **Stale** (>365 days — issuance blocked)
- Works in both light and dark mode (dark overlay background)
- Added tooltip to `ProjectOracleStatus` for Active/Inactive status dot

## Tested
- Tooltip appears on hover and focus
- Escape key dismisses tooltip
- aria-describedby links badge to tooltip text

Closes #356