### PR TITLE
feat: implement toast notification system for user feedback

### DIFF
--- a/frontend/components/Toast.tsx
+++ b/frontend/components/Toast.tsx
@@ -18,21 +18,40 @@ interface Props {
   onDismiss: (id: string) => void;
 }
 
-const toastConfig: Record<ToastType, { bg: string; border: string; icon: string; titleColor: string; live: "assertive" | "polite" }> = {
-  success: { bg: colors.verified.bg,   border: colors.verified.border,   icon: "✅", titleColor: colors.verified.text, live: "polite" },
-  error:   { bg: "#fee2e2",            border: "#fca5a5",                 icon: "❌", titleColor: "#991b1b",            live: "assertive" },
-  warning: { bg: colors.pending.bg,    border: colors.pending.border,     icon: "⚠️", titleColor: colors.pending.text,  live: "assertive" },
-  info:    { bg: "#eff6ff",            border: "#93c5fd",                 icon: "ℹ️", titleColor: "#1d4ed8",            live: "polite" },
+const toastConfig: Record<ToastType, { bg: string; border: string; icon: string; titleColor: string; progressColor: string; live: "assertive" | "polite" }> = {
+  success: { bg: colors.verified.bg,   border: colors.verified.border,   icon: "✅", titleColor: colors.verified.text, progressColor: "#16a34a", live: "polite" },
+  error:   { bg: "#fee2e2",            border: "#fca5a5",                 icon: "❌", titleColor: "#991b1b",            progressColor: "#dc2626", live: "assertive" },
+  warning: { bg: colors.pending.bg,    border: colors.pending.border,     icon: "⚠️", titleColor: colors.pending.text,  progressColor: "#d97706", live: "assertive" },
+  info:    { bg: "#eff6ff",            border: "#93c5fd",                 icon: "ℹ️", titleColor: "#1d4ed8",            progressColor: "#2563eb", live: "polite" },
 };
+
+const DISMISS_DELAY = 5000;
 
 function ToastItem({ toast, onDismiss }: { toast: ToastMessage; onDismiss: (id: string) => void }) {
   const cfg = toastConfig[toast.type];
+  // progress goes from 100 → 0 over DISMISS_DELAY ms
+  const [progress, setProgress] = useState(100);
 
   useEffect(() => {
-    // Errors persist until manually dismissed; all others auto-dismiss after 5 s
+    // Errors persist until manually dismissed
     if (toast.type === "error") return;
-    const t = setTimeout(() => onDismiss(toast.id), 5000);
-    return () => clearTimeout(t);
+
+    const start = performance.now();
+    let raf: number;
+
+    function tick(now: number) {
+      const elapsed = now - start;
+      const remaining = Math.max(0, 100 - (elapsed / DISMISS_DELAY) * 100);
+      setProgress(remaining);
+      if (elapsed < DISMISS_DELAY) {
+        raf = requestAnimationFrame(tick);
+      } else {
+        onDismiss(toast.id);
+      }
+    }
+
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
   }, [toast.id, toast.type, onDismiss]);
 
   return (
@@ -44,45 +63,66 @@ function ToastItem({ toast, onDismiss }: { toast: ToastMessage; onDismiss: (id: 
         background: cfg.bg,
         border: `1px solid ${cfg.border}`,
         borderRadius: "0.5rem",
-        padding: "0.875rem 1rem",
-        display: "flex",
-        gap: "0.75rem",
-        alignItems: "flex-start",
+        overflow: "hidden",
         boxShadow: "0 4px 12px rgb(0 0 0 / 0.1)",
         minWidth: "300px",
         maxWidth: "420px",
       }}
     >
-      <span aria-hidden="true" style={{ fontSize: "1rem", flexShrink: 0 }}>{cfg.icon}</span>
-      <div style={{ flex: 1 }}>
-        <p style={{ fontWeight: 700, fontSize: "0.875rem", color: cfg.titleColor, margin: 0 }}>
-          {toast.title}
-        </p>
-        {toast.message && (
-          <p style={{ fontSize: "0.8rem", color: colors.neutral[600], margin: "0.2rem 0 0" }}>
-            {toast.message}
-          </p>
-        )}
-        {toast.txHash && (
-          <a
-            href={`https://stellar.expert/explorer/testnet/tx/${toast.txHash}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="View transaction on Stellar Explorer (opens in new tab)"
-            style={{ fontSize: "0.75rem", color: colors.primary[600], fontFamily: "monospace" }}
-          >
-            View transaction →
-          </a>
-        )}
-      </div>
-      <button
-        type="button"
-        onClick={() => onDismiss(toast.id)}
-        aria-label={`Dismiss notification: ${toast.title}`}
-        style={{ background: "none", border: "none", cursor: "pointer", color: colors.neutral[400], fontSize: "1rem", padding: 0 }}
+      <div
+        style={{
+          padding: "0.875rem 1rem",
+          display: "flex",
+          gap: "0.75rem",
+          alignItems: "flex-start",
+        }}
       >
-        <span aria-hidden="true">✕</span>
-      </button>
+        <span aria-hidden="true" style={{ fontSize: "1rem", flexShrink: 0 }}>{cfg.icon}</span>
+        <div style={{ flex: 1 }}>
+          <p style={{ fontWeight: 700, fontSize: "0.875rem", color: cfg.titleColor, margin: 0 }}>
+            {toast.title}
+          </p>
+          {toast.message && (
+            <p style={{ fontSize: "0.8rem", color: colors.neutral[600], margin: "0.2rem 0 0" }}>
+              {toast.message}
+            </p>
+          )}
+          {toast.txHash && (
+            <a
+              href={`https://stellar.expert/explorer/testnet/tx/${toast.txHash}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="View transaction on Stellar Explorer (opens in new tab)"
+              style={{ fontSize: "0.75rem", color: colors.primary[600], fontFamily: "monospace" }}
+            >
+              View transaction →
+            </a>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => onDismiss(toast.id)}
+          aria-label={`Dismiss notification: ${toast.title}`}
+          style={{ background: "none", border: "none", cursor: "pointer", color: colors.neutral[400], fontSize: "1rem", padding: 0, flexShrink: 0 }}
+        >
+          <span aria-hidden="true">✕</span>
+        </button>
+      </div>
+
+      {/* Progress bar countdown — only for auto-dismissing toasts */}
+      {toast.type !== "error" && (
+        <div style={{ height: "3px", background: `${cfg.border}` }}>
+          <div
+            aria-hidden="true"
+            style={{
+              height: "100%",
+              width: `${progress}%`,
+              background: cfg.progressColor,
+              transition: "width 100ms linear",
+            }}
+          />
+        </div>
+      )}
     </div>
   );
 }
@@ -93,7 +133,7 @@ export default function Toast({ toasts, onDismiss }: Props) {
       aria-label="Notifications"
       style={{
         position: "fixed",
-        bottom: "1.5rem",
+        top: "1.5rem",
         right: "1.5rem",
         display: "flex",
         flexDirection: "column",


### PR DESCRIPTION
Closes #360

## Summary

Upgrades the existing toast component to meet all acceptance criteria: top-right positioning, visible progress bar countdown, and correct stacking/dismissal behaviour.

## Changes

- **Position** moved from bottom-right to **top-right**
- **Progress bar countdown** — smooth animation via `requestAnimationFrame` over 5 seconds; auto-dismisses when complete
- **Error toasts persist** — no progress bar, manual X button dismiss only
- **Max 3 toasts** — oldest is dropped when a 4th arrives
- **Manual dismiss** via X button on every toast
- All four variants unchanged: success (green), error (red), warning (amber), info (blue)
- ARIA roles and `aria-live` regions preserved for screen reader support

## Acceptance Criteria

- [x] Variants: success (green), error (red), warning (amber), info (blue)
- [x] Toasts appear in top-right corner and stack vertically
- [x] Auto-dismiss after 5 seconds with visible progress bar countdown
- [x] Manual dismiss via X button
- [x] Maximum 3 toasts; older ones dismissed first