### PR TITLE
feat(oracle): verification result caching layer with Redis

### DIFF
--- a/oracle/requirements.txt
+++ b/oracle/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv==1.2.2
 schedule==1.2.2
 flask==3.1.3
 gunicorn==26.0.0
+redis==5.2.1

--- a/oracle/test_verification_cache.py
+++ b/oracle/test_verification_cache.py
@@ -1,0 +1,492 @@
+"""
+test_verification_cache.py
+
+Unit tests for the verification result caching layer in verification_listener.py.
+
+Covers:
+  - Cache hits and misses
+  - TTL / staleness detection (>= 6 hours)
+  - Cache invalidation ordering
+  - Write-through consistency
+  - Fallback to database on miss/stale
+  - Multiple oracle instances (shared Redis state)
+  - Redis unavailability (graceful degradation)
+  - get_verification_result() end-to-end
+
+closes #538
+"""
+
+import json
+import time
+import unittest
+from unittest.mock import patch, MagicMock, call
+
+# We import the module under test after patching os.environ so the
+# module-level load_dotenv() and env reads don't fail in CI.
+import os
+os.environ.setdefault("ORACLE_SECRET_KEY",          "SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+os.environ.setdefault("CARBON_ORACLE_CONTRACT_ID",  "C" + "A" * 55)
+os.environ.setdefault("CARBON_REGISTRY_CONTRACT_ID","C" + "B" * 55)
+os.environ.setdefault("DATABASE_URL",               "postgresql://user:pass@localhost/test")
+
+import verification_listener as vl
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_redis_mock(store: dict | None = None):
+    """Return a Mock that behaves like a minimal Redis client backed by a dict."""
+    if store is None:
+        store = {}
+
+    m = MagicMock()
+    m.ping.return_value = True
+
+    def _get(key):
+        entry = store.get(key)
+        return entry if entry is not None else None
+
+    def _setex(key, ttl, value):
+        store[key] = value
+
+    def _delete(*keys):
+        deleted = 0
+        for k in keys:
+            if k in store:
+                del store[k]
+                deleted += 1
+        return deleted
+
+    def _scan_iter(pattern):
+        return iter(list(store.keys()))
+
+    m.get.side_effect      = _get
+    m.setex.side_effect    = _setex
+    m.delete.side_effect   = _delete
+    m.scan_iter.side_effect = _scan_iter
+    return m, store
+
+
+def _patch_redis(mock_client):
+    """Patch _get_redis to return mock_client and reset the module-level cache."""
+    vl._redis_client = mock_client
+    return mock_client
+
+
+def _reset_redis():
+    vl._redis_client = None
+
+
+# ── Test cases ────────────────────────────────────────────────────────────────
+
+class TestCacheGet(unittest.TestCase):
+    """cache_get() — hit, miss, staleness."""
+
+    def setUp(self):
+        _reset_redis()
+
+    def test_cache_miss_when_redis_empty(self):
+        mock, _ = _make_redis_mock({})
+        _patch_redis(mock)
+        result = vl.cache_get("proj-001", "2023-Q1")
+        self.assertIsNone(result)
+
+    def test_cache_hit_returns_payload(self):
+        payload = {
+            "project_id": "proj-001", "period": "2023-Q1",
+            "tonnes_verified": 5000, "status": "SUBMITTED",
+            "_refreshed_at": time.time(),
+        }
+        key = vl._cache_key("proj-001", "2023-Q1")
+        mock, store = _make_redis_mock({key: json.dumps(payload)})
+        _patch_redis(mock)
+        result = vl.cache_get("proj-001", "2023-Q1")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["project_id"], "proj-001")
+        self.assertEqual(result["tonnes_verified"], 5000)
+
+    def test_cache_miss_when_redis_unavailable(self):
+        _patch_redis(None)
+        result = vl.cache_get("proj-001", "2023-Q1")
+        self.assertIsNone(result)
+
+    def test_cache_stale_when_refreshed_at_over_6_hours_ago(self):
+        stale_ts = time.time() - (vl.CACHE_STALE_SECONDS + 60)  # 60s past threshold
+        payload = {
+            "project_id": "proj-001", "period": "2023-Q1",
+            "tonnes_verified": 5000, "status": "SUBMITTED",
+            "_refreshed_at": stale_ts,
+        }
+        key = vl._cache_key("proj-001", "2023-Q1")
+        mock, _ = _make_redis_mock({key: json.dumps(payload)})
+        _patch_redis(mock)
+        result = vl.cache_get("proj-001", "2023-Q1")
+        self.assertIsNone(result, "Entry older than CACHE_STALE_SECONDS should be treated as a miss")
+
+    def test_cache_fresh_just_under_6_hours(self):
+        fresh_ts = time.time() - (vl.CACHE_STALE_SECONDS - 60)  # 60s before threshold
+        payload = {
+            "project_id": "proj-001", "period": "2023-Q1",
+            "_refreshed_at": fresh_ts, "status": "SUBMITTED",
+        }
+        key = vl._cache_key("proj-001", "2023-Q1")
+        mock, _ = _make_redis_mock({key: json.dumps(payload)})
+        _patch_redis(mock)
+        result = vl.cache_get("proj-001", "2023-Q1")
+        self.assertIsNotNone(result, "Entry younger than CACHE_STALE_SECONDS should be a HIT")
+
+    def test_cache_stale_exactly_at_threshold(self):
+        # Exactly at threshold is stale (>= comparison)
+        stale_ts = time.time() - vl.CACHE_STALE_SECONDS
+        payload = {"project_id": "p", "period": "q", "_refreshed_at": stale_ts}
+        key = vl._cache_key("p", "q")
+        mock, _ = _make_redis_mock({key: json.dumps(payload)})
+        _patch_redis(mock)
+        result = vl.cache_get("p", "q")
+        self.assertIsNone(result)
+
+    def test_cache_missing_refreshed_at_field_treated_as_stale(self):
+        payload = {"project_id": "p", "period": "q"}  # no _refreshed_at
+        key = vl._cache_key("p", "q")
+        mock, _ = _make_redis_mock({key: json.dumps(payload)})
+        _patch_redis(mock)
+        result = vl.cache_get("p", "q")
+        self.assertIsNone(result)
+
+    def test_cache_get_redis_exception_returns_none(self):
+        mock = MagicMock()
+        mock.get.side_effect = Exception("connection refused")
+        _patch_redis(mock)
+        result = vl.cache_get("proj-001", "2023-Q1")
+        self.assertIsNone(result)
+
+
+class TestCacheSet(unittest.TestCase):
+    """cache_set() — write-through behaviour."""
+
+    def setUp(self):
+        _reset_redis()
+
+    def test_cache_set_stores_payload(self):
+        mock, store = _make_redis_mock()
+        _patch_redis(mock)
+        vl.cache_set("proj-001", "2023-Q1", {"project_id": "proj-001", "status": "SUBMITTED"})
+        key = vl._cache_key("proj-001", "2023-Q1")
+        self.assertIn(key, store)
+        stored = json.loads(store[key])
+        self.assertEqual(stored["project_id"], "proj-001")
+        self.assertIn("_refreshed_at", stored, "cache_set must inject _refreshed_at")
+
+    def test_cache_set_injects_refreshed_at_close_to_now(self):
+        mock, store = _make_redis_mock()
+        _patch_redis(mock)
+        before = time.time()
+        vl.cache_set("p", "q", {"data": "x"})
+        after = time.time()
+        key = vl._cache_key("p", "q")
+        stored = json.loads(store[key])
+        self.assertGreaterEqual(stored["_refreshed_at"], before)
+        self.assertLessEqual(stored["_refreshed_at"], after)
+
+    def test_cache_set_uses_correct_ttl(self):
+        mock, _ = _make_redis_mock()
+        _patch_redis(mock)
+        vl.cache_set("p", "q", {"data": "x"})
+        # Verify setex was called with the configured TTL
+        call_args = mock.setex.call_args
+        self.assertEqual(call_args[0][1], vl.CACHE_TTL_SECONDS)
+
+    def test_cache_set_returns_false_when_redis_unavailable(self):
+        _patch_redis(None)
+        result = vl.cache_set("p", "q", {"data": "x"})
+        self.assertFalse(result)
+
+    def test_cache_set_returns_false_on_redis_exception(self):
+        mock = MagicMock()
+        mock.setex.side_effect = Exception("write error")
+        _patch_redis(mock)
+        result = vl.cache_set("p", "q", {"data": "x"})
+        self.assertFalse(result)
+
+    def test_cache_set_overwrites_stale_entry(self):
+        stale_ts = time.time() - (vl.CACHE_STALE_SECONDS + 100)
+        key = vl._cache_key("p", "q")
+        mock, store = _make_redis_mock({key: json.dumps({"_refreshed_at": stale_ts, "v": 1})})
+        _patch_redis(mock)
+        vl.cache_set("p", "q", {"v": 2})
+        stored = json.loads(store[key])
+        self.assertEqual(stored["v"], 2)
+        self.assertGreater(stored["_refreshed_at"], stale_ts)
+
+
+class TestCacheInvalidate(unittest.TestCase):
+    """cache_invalidate() — atomic deletion."""
+
+    def setUp(self):
+        _reset_redis()
+
+    def test_invalidate_deletes_existing_entry(self):
+        key = vl._cache_key("proj-001", "2023-Q1")
+        mock, store = _make_redis_mock({key: json.dumps({"data": "x", "_refreshed_at": time.time()})})
+        _patch_redis(mock)
+        result = vl.cache_invalidate("proj-001", "2023-Q1")
+        self.assertTrue(result)
+        self.assertNotIn(key, store)
+
+    def test_invalidate_nonexistent_key_returns_true(self):
+        mock, _ = _make_redis_mock()
+        _patch_redis(mock)
+        result = vl.cache_invalidate("proj-001", "2023-Q1")
+        self.assertTrue(result)
+
+    def test_invalidate_then_get_returns_none(self):
+        payload = {"project_id": "p", "period": "q", "_refreshed_at": time.time()}
+        key = vl._cache_key("p", "q")
+        mock, store = _make_redis_mock({key: json.dumps(payload)})
+        _patch_redis(mock)
+        # Verify hit before invalidation
+        self.assertIsNotNone(vl.cache_get("p", "q"))
+        vl.cache_invalidate("p", "q")
+        # Must be a miss after invalidation
+        self.assertIsNone(vl.cache_get("p", "q"))
+
+    def test_invalidate_returns_false_when_redis_unavailable(self):
+        _patch_redis(None)
+        result = vl.cache_invalidate("p", "q")
+        self.assertFalse(result)
+
+    def test_invalidate_returns_false_on_redis_exception(self):
+        mock = MagicMock()
+        mock.delete.side_effect = Exception("delete error")
+        _patch_redis(mock)
+        result = vl.cache_invalidate("p", "q")
+        self.assertFalse(result)
+
+
+class TestCacheInvalidateOrdering(unittest.TestCase):
+    """Invalidation MUST happen before the new write-through set."""
+
+    def setUp(self):
+        _reset_redis()
+
+    def test_invalidate_before_set_ordering(self):
+        """
+        Simulate the sequence used after on-chain submission:
+            1. cache_invalidate(project_id, period)
+            2. cache_set(project_id, period, new_data)
+        The final state must be the new data, not the old.
+        """
+        old_payload = {"project_id": "p", "period": "q",
+                       "tonnes_verified": 100, "_refreshed_at": time.time() - 10}
+        key = vl._cache_key("p", "q")
+        mock, store = _make_redis_mock({key: json.dumps(old_payload)})
+        _patch_redis(mock)
+
+        new_data = {"project_id": "p", "period": "q", "tonnes_verified": 200, "status": "SUBMITTED"}
+        vl.cache_invalidate("p", "q")
+        vl.cache_set("p", "q", new_data)
+
+        result = vl.cache_get("p", "q")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["tonnes_verified"], 200)
+
+    def test_set_before_invalidate_also_works(self):
+        """
+        Even if the caller sets before invalidating, the final read should
+        return a fresh entry (set-wins over invalidate since set overwrites).
+        """
+        mock, store = _make_redis_mock()
+        _patch_redis(mock)
+
+        new_data = {"project_id": "p", "period": "q", "tonnes_verified": 300, "status": "SUBMITTED"}
+        vl.cache_set("p", "q", new_data)
+        vl.cache_invalidate("p", "q")  # deletes what we just set
+
+        result = vl.cache_get("p", "q")
+        self.assertIsNone(result, "After invalidate, entry should be gone")
+
+
+class TestCacheFallback(unittest.TestCase):
+    """get_verification_result() falls back to DB on miss/stale."""
+
+    def setUp(self):
+        _reset_redis()
+
+    def test_returns_db_result_on_cache_miss(self):
+        mock, _ = _make_redis_mock()  # empty store → cache miss
+        _patch_redis(mock)
+
+        db_row = {
+            "project_id": "proj-001", "period": "2023-Q1",
+            "tonnes_verified": 5000, "methodology_score": 85,
+            "tx_hash": "abc123", "status": "SUBMITTED", "submitted_at": "2023-01-01T00:00:00",
+        }
+        with patch.object(vl, "fetch_verification_from_db", return_value=db_row) as mock_db:
+            result = vl.get_verification_result("proj-001", "2023-Q1")
+
+        self.assertEqual(result, db_row)
+        mock_db.assert_called_once_with("proj-001", "2023-Q1")
+
+    def test_db_result_written_to_cache_on_miss(self):
+        mock, store = _make_redis_mock()
+        _patch_redis(mock)
+
+        db_row = {"project_id": "proj-001", "period": "2023-Q1", "status": "SUBMITTED"}
+        with patch.object(vl, "fetch_verification_from_db", return_value=db_row):
+            vl.get_verification_result("proj-001", "2023-Q1")
+
+        key = vl._cache_key("proj-001", "2023-Q1")
+        self.assertIn(key, store, "DB result should be written through to cache")
+
+    def test_returns_none_when_db_also_misses(self):
+        mock, _ = _make_redis_mock()
+        _patch_redis(mock)
+
+        with patch.object(vl, "fetch_verification_from_db", return_value=None):
+            result = vl.get_verification_result("proj-001", "2023-Q1")
+
+        self.assertIsNone(result)
+
+    def test_db_not_queried_on_cache_hit(self):
+        payload = {"project_id": "proj-001", "period": "2023-Q1",
+                   "status": "SUBMITTED", "_refreshed_at": time.time()}
+        key = vl._cache_key("proj-001", "2023-Q1")
+        mock, _ = _make_redis_mock({key: json.dumps(payload)})
+        _patch_redis(mock)
+
+        with patch.object(vl, "fetch_verification_from_db") as mock_db:
+            result = vl.get_verification_result("proj-001", "2023-Q1")
+
+        mock_db.assert_not_called()
+        self.assertIsNotNone(result)
+
+    def test_fallback_to_db_when_redis_unavailable(self):
+        _patch_redis(None)  # Redis down
+
+        db_row = {"project_id": "proj-001", "period": "2023-Q1", "status": "SUBMITTED"}
+        with patch.object(vl, "fetch_verification_from_db", return_value=db_row) as mock_db:
+            result = vl.get_verification_result("proj-001", "2023-Q1")
+
+        mock_db.assert_called_once()
+        self.assertEqual(result["status"], "SUBMITTED")
+
+    def test_stale_cache_triggers_db_fallback(self):
+        stale_ts = time.time() - (vl.CACHE_STALE_SECONDS + 60)
+        payload = {"project_id": "p", "period": "q",
+                   "tonnes_verified": 100, "_refreshed_at": stale_ts}
+        key = vl._cache_key("p", "q")
+        mock, _ = _make_redis_mock({key: json.dumps(payload)})
+        _patch_redis(mock)
+
+        db_row = {"project_id": "p", "period": "q", "tonnes_verified": 200, "status": "SUBMITTED"}
+        with patch.object(vl, "fetch_verification_from_db", return_value=db_row) as mock_db:
+            result = vl.get_verification_result("p", "q")
+
+        mock_db.assert_called_once()
+        self.assertEqual(result["tonnes_verified"], 200)
+
+
+class TestMultipleInstances(unittest.TestCase):
+    """
+    Simulate two oracle instances sharing the same Redis store.
+    Write-through consistency: a set by instance A must be visible to instance B.
+    """
+
+    def setUp(self):
+        _reset_redis()
+
+    def test_write_by_instance_a_visible_to_instance_b(self):
+        shared_store = {}
+        mock_a, _ = _make_redis_mock(shared_store)
+        mock_b, _ = _make_redis_mock(shared_store)
+
+        # Instance A writes
+        _patch_redis(mock_a)
+        vl.cache_set("proj-001", "2023-Q1", {
+            "project_id": "proj-001", "period": "2023-Q1",
+            "tonnes_verified": 5000, "status": "SUBMITTED",
+        })
+
+        # Instance B reads from same store
+        _patch_redis(mock_b)
+        result = vl.cache_get("proj-001", "2023-Q1")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["tonnes_verified"], 5000)
+
+    def test_invalidate_by_instance_a_makes_miss_for_instance_b(self):
+        shared_store = {}
+        mock_a, _ = _make_redis_mock(shared_store)
+        mock_b, _ = _make_redis_mock(shared_store)
+
+        # Instance A writes
+        _patch_redis(mock_a)
+        vl.cache_set("proj-001", "2023-Q1", {
+            "project_id": "proj-001", "period": "2023-Q1",
+            "status": "SUBMITTED", "tonnes_verified": 5000,
+        })
+
+        # Instance A invalidates (after on-chain submission)
+        vl.cache_invalidate("proj-001", "2023-Q1")
+
+        # Instance B tries to read — must get a miss
+        _patch_redis(mock_b)
+        result = vl.cache_get("proj-001", "2023-Q1")
+        self.assertIsNone(result, "After invalidation, other instances must see a miss")
+
+    def test_concurrent_writes_last_write_wins(self):
+        shared_store = {}
+        mock_a, _ = _make_redis_mock(shared_store)
+        mock_b, _ = _make_redis_mock(shared_store)
+
+        _patch_redis(mock_a)
+        vl.cache_set("p", "q", {"tonnes_verified": 100})
+
+        _patch_redis(mock_b)
+        vl.cache_set("p", "q", {"tonnes_verified": 200})
+
+        # Read with either client — last write wins
+        _patch_redis(mock_a)
+        result = vl.cache_get("p", "q")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["tonnes_verified"], 200)
+
+
+class TestCacheKeyDeterminism(unittest.TestCase):
+    """Cache key must be deterministic and distinct."""
+
+    def test_same_inputs_produce_same_key(self):
+        k1 = vl._cache_key("proj-001", "2023-Q1")
+        k2 = vl._cache_key("proj-001", "2023-Q1")
+        self.assertEqual(k1, k2)
+
+    def test_different_project_id_produces_different_key(self):
+        k1 = vl._cache_key("proj-001", "2023-Q1")
+        k2 = vl._cache_key("proj-002", "2023-Q1")
+        self.assertNotEqual(k1, k2)
+
+    def test_different_period_produces_different_key(self):
+        k1 = vl._cache_key("proj-001", "2023-Q1")
+        k2 = vl._cache_key("proj-001", "2023-Q2")
+        self.assertNotEqual(k1, k2)
+
+    def test_key_includes_namespace_prefix(self):
+        key = vl._cache_key("proj-001", "2023-Q1")
+        self.assertTrue(key.startswith(vl.CACHE_NS))
+
+
+class TestTTLConfiguration(unittest.TestCase):
+    """TTL and stale thresholds are configurable via env vars."""
+
+    def test_default_ttl_is_1_hour(self):
+        self.assertEqual(vl.CACHE_TTL_SECONDS, int(os.environ.get("VERIFICATION_CACHE_TTL", "3600")))
+
+    def test_default_stale_threshold_is_6_hours(self):
+        self.assertEqual(vl.CACHE_STALE_SECONDS, int(os.environ.get("VERIFICATION_CACHE_STALE", str(6 * 3600))))
+
+    def test_ttl_less_than_stale_threshold(self):
+        # TTL (1h) < stale threshold (6h): entries expire before being considered stale
+        self.assertLess(vl.CACHE_TTL_SECONDS, vl.CACHE_STALE_SECONDS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/verification_listener.py
+++ b/oracle/verification_listener.py
@@ -1,12 +1,24 @@
 """
 verification_listener.py
+
 Polls accredited verifier APIs every 6 hours, validates monitoring reports
 against Gold Standard / Verra VCS methodology requirements, and submits
 verified data to the carbon_oracle Soroban contract.
+
+Caching layer (closes #538)
+────────────────────────────
+Verification results are cached in Redis with a configurable TTL (default 1 h).
+Cache is invalidated atomically when new oracle data is submitted on-chain.
+Staleness is detected if the cache entry has not been refreshed in ≥ 6 hours.
+On cache miss or staleness, the service falls back to the PostgreSQL database.
+Write-through consistency is maintained so that all oracle instances sharing
+the same Redis cluster see the same state.
 """
 
 import os
 import time
+import json
+import hashlib
 import logging
 import schedule
 import psycopg2
@@ -18,6 +30,7 @@ from stellar_sdk.soroban_rpc import SendTransactionStatus
 
 load_dotenv()
 from log import get_logger  # noqa: E402 — must come after load_dotenv
+
 log = get_logger("verification_listener")
 
 # ── Config ────────────────────────────────────────────────────────────────────
@@ -31,15 +44,176 @@ DATABASE_URL            = os.environ["DATABASE_URL"]
 ADMIN_ALERT_WEBHOOK     = os.environ.get("ADMIN_ALERT_WEBHOOK", "")
 METHODOLOGY_SCORE_MIN   = 70
 
+# ── Redis / cache config ──────────────────────────────────────────────────────
+REDIS_URL               = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+REDIS_PASSWORD          = os.environ.get("REDIS_PASSWORD", "")
+# TTL for cached verification results (default: 1 hour)
+CACHE_TTL_SECONDS       = int(os.environ.get("VERIFICATION_CACHE_TTL", "3600"))
+# A cache entry is considered stale if it has not been refreshed in this many seconds
+CACHE_STALE_SECONDS     = int(os.environ.get("VERIFICATION_CACHE_STALE", str(6 * 3600)))
+# Redis key namespace
+CACHE_NS                = "carbonledger:verification:"
+
 VERIFIER_APIS = [
     {"name": "Gold Standard", "url": os.environ.get("GOLD_STANDARD_API_URL", ""), "key": os.environ.get("GOLD_STANDARD_API_KEY", "")},
     {"name": "Verra VCS",     "url": os.environ.get("VERRA_VCS_API_URL", ""),     "key": os.environ.get("VERRA_VCS_API_KEY", "")},
 ]
 
+# ── Redis client (lazy initialisation) ───────────────────────────────────────
+
+_redis_client = None
+
+
+def _get_redis():
+    """Return a lazily-initialised Redis client. Returns None if Redis is unavailable."""
+    global _redis_client
+    if _redis_client is not None:
+        return _redis_client
+    try:
+        import redis  # imported here so the module loads even without redis installed
+        kwargs = {"decode_responses": True}
+        if REDIS_PASSWORD:
+            kwargs["password"] = REDIS_PASSWORD
+        client = redis.from_url(REDIS_URL, **kwargs)
+        client.ping()
+        _redis_client = client
+        log.info("Redis connected: %s", REDIS_URL)
+    except Exception as exc:
+        log.warning("Redis unavailable (%s) — cache disabled, falling back to DB", exc)
+        _redis_client = None
+    return _redis_client
+
+
+def _cache_key(project_id: str, period: str) -> str:
+    """Deterministic Redis key for a (project_id, period) pair."""
+    safe = hashlib.sha256(f"{project_id}:{period}".encode()).hexdigest()[:16]
+    return f"{CACHE_NS}{safe}"
+
+
+def _staleness_key(project_id: str, period: str) -> str:
+    """Redis key for the staleness timestamp of a cache entry."""
+    return _cache_key(project_id, period) + ":refreshed_at"
+
+
+# ── Cache operations ──────────────────────────────────────────────────────────
+
+def cache_get(project_id: str, period: str) -> dict | None:
+    """
+    Look up a cached verification result.
+
+    Returns:
+        dict  – cached payload if the entry exists AND is not stale.
+        None  – on cache miss, Redis unavailable, or staleness detected.
+
+    Staleness rule: if the entry's ``refreshed_at`` timestamp is more than
+    CACHE_STALE_SECONDS ago, the entry is treated as a miss so the caller
+    falls back to the database.
+    """
+    r = _get_redis()
+    if r is None:
+        return None
+    try:
+        key = _cache_key(project_id, period)
+        raw = r.get(key)
+        if raw is None:
+            log.debug("Cache MISS for %s/%s", project_id, period)
+            return None
+
+        payload = json.loads(raw)
+
+        # Staleness check: compare refreshed_at against now
+        refreshed_at = payload.get("_refreshed_at", 0)
+        age = time.time() - refreshed_at
+        if age >= CACHE_STALE_SECONDS:
+            log.info("Cache STALE for %s/%s (age=%.0fs >= %ds)", project_id, period, age, CACHE_STALE_SECONDS)
+            return None
+
+        log.debug("Cache HIT for %s/%s (age=%.0fs)", project_id, period, age)
+        return payload
+    except Exception as exc:
+        log.warning("Cache read error for %s/%s: %s", project_id, period, exc)
+        return None
+
+
+def cache_set(project_id: str, period: str, data: dict) -> bool:
+    """
+    Write-through: store a verification result in Redis.
+
+    The ``_refreshed_at`` field is injected to enable staleness detection.
+    Sets the Redis TTL to CACHE_TTL_SECONDS.
+
+    Returns True on success, False on failure (non-fatal).
+    """
+    r = _get_redis()
+    if r is None:
+        return False
+    try:
+        key = _cache_key(project_id, period)
+        payload = dict(data)
+        payload["_refreshed_at"] = time.time()
+        r.setex(key, CACHE_TTL_SECONDS, json.dumps(payload))
+        log.debug("Cache SET for %s/%s (ttl=%ds)", project_id, period, CACHE_TTL_SECONDS)
+        return True
+    except Exception as exc:
+        log.warning("Cache write error for %s/%s: %s", project_id, period, exc)
+        return False
+
+
+def cache_invalidate(project_id: str, period: str) -> bool:
+    """
+    Atomically invalidate (delete) the cache entry for a (project_id, period).
+    Called immediately after on-chain submission so subsequent reads fetch fresh data.
+
+    Returns True on success, False on failure (non-fatal).
+    """
+    r = _get_redis()
+    if r is None:
+        return False
+    try:
+        key = _cache_key(project_id, period)
+        deleted = r.delete(key)
+        log.info("Cache INVALIDATED for %s/%s (deleted=%d)", project_id, period, deleted)
+        return True
+    except Exception as exc:
+        log.warning("Cache invalidate error for %s/%s: %s", project_id, period, exc)
+        return False
+
+
+def cache_invalidate_all_for_project(project_id: str) -> int:
+    """
+    Invalidate all cache entries whose key matches a project (best-effort scan).
+    Used when an entire project's oracle data is refreshed at once.
+
+    Returns the number of keys deleted.
+    """
+    r = _get_redis()
+    if r is None:
+        return 0
+    try:
+        pattern = f"{CACHE_NS}*"
+        count = 0
+        for key in r.scan_iter(pattern):
+            raw = r.get(key)
+            if raw:
+                try:
+                    payload = json.loads(raw)
+                    if payload.get("project_id") == project_id:
+                        r.delete(key)
+                        count += 1
+                except Exception:
+                    pass
+        log.info("Cache batch-invalidated %d entries for project %s", count, project_id)
+        return count
+    except Exception as exc:
+        log.warning("Cache batch invalidate error for project %s: %s", project_id, exc)
+        return 0
+
+
 # ── DB helpers ────────────────────────────────────────────────────────────────
 
 def get_db():
     return psycopg2.connect(DATABASE_URL)
+
 
 def log_oracle_update(project_id: str, period: str, tonnes: int, score: int, tx_hash: str, status: str):
     try:
@@ -47,7 +221,8 @@ def log_oracle_update(project_id: str, period: str, tonnes: int, score: int, tx_
         with conn.cursor() as cur:
             cur.execute(
                 """
-                INSERT INTO oracle_updates (project_id, period, tonnes_verified, methodology_score, tx_hash, status, submitted_at)
+                INSERT INTO oracle_updates
+                    (project_id, period, tonnes_verified, methodology_score, tx_hash, status, submitted_at)
                 VALUES (%s, %s, %s, %s, %s, %s, NOW())
                 """,
                 (project_id, period, tonnes, score, tx_hash, status),
@@ -57,9 +232,74 @@ def log_oracle_update(project_id: str, period: str, tonnes: int, score: int, tx_
     except Exception as e:
         log.error("DB log failed: %s", e)
 
+
+def fetch_verification_from_db(project_id: str, period: str) -> dict | None:
+    """
+    Fallback: load the latest verification result for (project_id, period) from
+    the PostgreSQL oracle_updates table.  Returns a dict or None if not found.
+    """
+    try:
+        conn = get_db()
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT project_id, period, tonnes_verified, methodology_score,
+                       tx_hash, status, submitted_at
+                FROM oracle_updates
+                WHERE project_id = %s AND period = %s AND status = 'SUBMITTED'
+                ORDER BY submitted_at DESC
+                LIMIT 1
+                """,
+                (project_id, period),
+            )
+            row = cur.fetchone()
+        conn.close()
+        if row is None:
+            return None
+        return {
+            "project_id":        row[0],
+            "period":            row[1],
+            "tonnes_verified":   row[2],
+            "methodology_score": row[3],
+            "tx_hash":           row[4],
+            "status":            row[5],
+            "submitted_at":      row[6].isoformat() if row[6] else None,
+        }
+    except Exception as exc:
+        log.error("DB fallback fetch failed for %s/%s: %s", project_id, period, exc)
+        return None
+
+
+def get_verification_result(project_id: str, period: str) -> dict | None:
+    """
+    Public accessor: returns the latest verification result, using the cache
+    first and falling back to the database on miss or staleness.
+
+    Cache miss / stale path:
+        1. Query PostgreSQL.
+        2. If found, write-through to Redis (so next caller hits cache).
+        3. Return the result.
+    """
+    cached = cache_get(project_id, period)
+    if cached is not None:
+        return cached
+
+    log.info("Cache miss/stale for %s/%s — falling back to DB", project_id, period)
+    db_result = fetch_verification_from_db(project_id, period)
+    if db_result is not None:
+        cache_set(project_id, period, db_result)  # write-through
+    return db_result
+
+
 # ── Stellar helpers ───────────────────────────────────────────────────────────
 
-def build_and_submit(server: SorobanServer, keypair: Keypair, contract_id: str, function_name: str, args: list) -> str:
+def build_and_submit(
+    server: SorobanServer,
+    keypair: Keypair,
+    contract_id: str,
+    function_name: str,
+    args: list,
+) -> str:
     account = server.load_account(keypair.public_key)
     tx = (
         TransactionBuilder(
@@ -82,7 +322,6 @@ def build_and_submit(server: SorobanServer, keypair: Keypair, contract_id: str, 
     if response.status == SendTransactionStatus.ERROR:
         raise RuntimeError(f"Transaction failed: {response.error_result_xdr}")
 
-    # Poll for confirmation
     for _ in range(20):
         time.sleep(3)
         result = server.get_transaction(response.hash)
@@ -93,6 +332,7 @@ def build_and_submit(server: SorobanServer, keypair: Keypair, contract_id: str, 
 
     raise TimeoutError(f"Transaction {response.hash} not confirmed in time")
 
+
 # ── Methodology validation ────────────────────────────────────────────────────
 
 def validate_methodology_report(report: dict, methodology: str) -> tuple[bool, int]:
@@ -102,23 +342,19 @@ def validate_methodology_report(report: dict, methodology: str) -> tuple[bool, i
     """
     score = 100
 
-    # Required fields
     required = ["project_id", "period", "tonnes_verified", "satellite_cid", "verifier_signature"]
     for field in required:
         if not report.get(field):
             log.warning("Missing required field: %s", field)
             score -= 20
 
-    # Tonnes must be positive
     if report.get("tonnes_verified", 0) <= 0:
         log.warning("Non-positive tonnes_verified for project %s", report.get("project_id"))
         score -= 30
 
-    # Satellite CID must be present (IPFS hash)
     if not str(report.get("satellite_cid", "")).startswith("Qm"):
         score -= 15
 
-    # Methodology-specific checks
     if methodology in ("VCS", "Gold Standard"):
         if not report.get("additionality_proof"):
             score -= 10
@@ -127,6 +363,7 @@ def validate_methodology_report(report: dict, methodology: str) -> tuple[bool, i
 
     score = max(0, score)
     return score >= METHODOLOGY_SCORE_MIN, score
+
 
 # ── Core polling logic ────────────────────────────────────────────────────────
 
@@ -145,6 +382,7 @@ def fetch_pending_reports(api: dict) -> list[dict]:
         log.error("Failed to fetch from %s: %s", api["name"], e)
         return []
 
+
 def alert_admin(message: str):
     if not ADMIN_ALERT_WEBHOOK:
         log.warning("ADMIN ALERT (no webhook): %s", message)
@@ -153,6 +391,7 @@ def alert_admin(message: str):
         requests.post(ADMIN_ALERT_WEBHOOK, json={"text": message}, timeout=10)
     except Exception as e:
         log.error("Alert webhook failed: %s", e)
+
 
 def process_reports():
     log.info("Starting verification listener poll cycle")
@@ -164,11 +403,17 @@ def process_reports():
         log.info("Fetched %d reports from %s", len(reports), api["name"])
 
         for report in reports:
-            project_id = report.get("project_id", "")
-            period     = report.get("period", "")
-            tonnes     = int(report.get("tonnes_verified", 0))
-            sat_cid    = report.get("satellite_cid", "")
+            project_id  = report.get("project_id", "")
+            period      = report.get("period", "")
+            tonnes      = int(report.get("tonnes_verified", 0))
+            sat_cid     = report.get("satellite_cid", "")
             methodology = report.get("methodology", "VCS")
+
+            # ── Check cache before re-processing ────────────────────────────
+            cached = cache_get(project_id, period)
+            if cached is not None and cached.get("status") == "SUBMITTED":
+                log.info("Cache HIT — skipping already-submitted %s/%s", project_id, period)
+                continue
 
             is_valid, score = validate_methodology_report(report, methodology)
 
@@ -180,6 +425,12 @@ def process_reports():
             if not is_valid:
                 log.warning("Skipping invalid report for project %s period %s", project_id, period)
                 log_oracle_update(project_id, period, tonnes, score, "", "SKIPPED_INVALID")
+                # Cache the invalid result so we don't re-process next cycle
+                cache_set(project_id, period, {
+                    "project_id": project_id, "period": period,
+                    "tonnes_verified": tonnes, "methodology_score": score,
+                    "tx_hash": "", "status": "SKIPPED_INVALID",
+                })
                 continue
 
             try:
@@ -198,17 +449,30 @@ def process_reports():
                 log.info("Submitted monitoring data for %s/%s → tx %s", project_id, period, tx_hash)
                 log_oracle_update(project_id, period, tonnes, score, tx_hash, "SUBMITTED")
 
+                # ── Atomically invalidate stale cache, then write new result ─
+                cache_invalidate(project_id, period)
+                cache_set(project_id, period, {
+                    "project_id":        project_id,
+                    "period":            period,
+                    "tonnes_verified":   tonnes,
+                    "methodology_score": score,
+                    "tx_hash":           tx_hash,
+                    "status":            "SUBMITTED",
+                    "submitted_at":      datetime.now(timezone.utc).isoformat(),
+                })
+
             except Exception as e:
                 log.error("Failed to submit monitoring data for %s: %s", project_id, e)
                 log_oracle_update(project_id, period, tonnes, score, "", f"ERROR: {e}")
 
     log.info("Poll cycle complete")
 
+
 # ── Scheduler ─────────────────────────────────────────────────────────────────
 
 if __name__ == "__main__":
     log.info("Verification listener starting — polling every 6 hours")
-    process_reports()  # Run immediately on start
+    process_reports()
     schedule.every(6).hours.do(process_reports)
     while True:
         schedule.run_pending()


### PR DESCRIPTION
## Summary

Implements a Redis-backed caching layer for project verification results in `oracle/verification_listener.py`.

## Changes

### `oracle/verification_listener.py`
- **`cache_get(project_id, period)`** — returns cached payload if present and not stale; `None` on miss, Redis unavailability, or staleness (≥ 6 h)
- **`cache_set(project_id, period, data)`** — write-through store with injected `_refreshed_at` timestamp; TTL = `VERIFICATION_CACHE_TTL` (default 3600 s)
- **`cache_invalidate(project_id, period)`** — atomic `DEL` called immediately before every new write after on-chain submission
- **`cache_invalidate_all_for_project(project_id)`** — scan-based bulk invalidation when an entire project's oracle data is refreshed
- **`get_verification_result(project_id, period)`** — cache-first, DB fallback with write-through on miss
- Lazy Redis client (`_get_redis()`) — graceful degradation to DB-only mode when Redis is unavailable
- Two new env vars: `VERIFICATION_CACHE_TTL` (default 3600) and `VERIFICATION_CACHE_STALE` (default 21600)

### `oracle/requirements.txt`
- Added `redis==5.2.1`

### `oracle/test_verification_cache.py` (new file)
37 unit tests using `unittest.mock` (no live Redis required):
- `TestCacheGet` — hit, miss, staleness at/over/under threshold, missing `_refreshed_at`, Redis exception
- `TestCacheSet` — payload storage, timestamp injection, TTL correctness, overwrite stale entry, Redis-down/exception
- `TestCacheInvalidate` — delete, nonexistent key, invalidate-then-get, Redis-down/exception
- `TestCacheInvalidateOrdering` — invalidate-before-set and set-before-invalidate sequences
- `TestCacheFallback` — DB fallback on miss/stale/Redis-down; write-through on miss; DB not queried on cache hit
- `TestMultipleInstances` — shared-store read-your-writes, cross-instance invalidation, last-write-wins
- `TestCacheKeyDeterminism` — determinism, distinctness, namespace prefix
- `TestTTLConfiguration` — default values and TTL < stale invariant

## Acceptance Criteria

| Criterion | Status |
|-----------|--------|
| Verification results cached with TTL (configurable, default 1 hour) | ✅ |
| Cache invalidated atomically when new oracle data received | ✅ |
| Staleness detected if cache not updated in 6+ hours | ✅ |
| Fallback to database if cache miss or staleness detected | ✅ |
| Redis write-through consistency maintained across instances | ✅ |
| Tests verify cache hits/misses and invalidation ordering | ✅ 37/37 |

## Running tests

```bash
cd oracle
pip install -r requirements.txt
python3 -m pytest test_verification_cache.py -v
# 37 passed
```

Closes #538