### PR TITLE
accessibility: improve keyboard navigation and WCAG compliance on mar…

### DIFF
--- a/frontend/app/marketplace/page.tsx
+++ b/frontend/app/marketplace/page.tsx
@@ -168,6 +168,12 @@ function MarketplaceContent() {
                     <div style={{ display: "flex", gap: "0.5rem" }}>
                       <a
                         href={`/buy?listing=${listing.listingId}`}
+                        onKeyDown={(e) => {
+                          if (e.key === " ") {
+                            e.preventDefault();
+                            window.location.href = `/buy?listing=${listing.listingId}`;
+                          }
+                        }}
                         style={{
                           padding: "0.5rem 0.875rem", fontSize: "0.8rem", fontWeight: 600,
                           border: `1px solid ${colors.primary[300]}`, borderRadius: "0.375rem",

--- a/frontend/components/CreditCard.tsx
+++ b/frontend/components/CreditCard.tsx
@@ -153,6 +153,12 @@ export default function CreditCard({ listing, onAddToCart, onBuyNow }: Props) {
           {onBuyNow && (
             <button
               onClick={() => onBuyNow(listing)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onBuyNow(listing);
+                }
+              }}
               aria-label={`Purchase carbon credits from ${projectLabel}`}
               style={{
                 flex: 1,
@@ -172,6 +178,12 @@ export default function CreditCard({ listing, onAddToCart, onBuyNow }: Props) {
           {onAddToCart && (
             <button
               onClick={() => onAddToCart(listing)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onAddToCart(listing);
+                }
+              }}
               aria-label={`Add ${projectLabel} to cart`}
               style={{
                 flex: 1,

--- a/frontend/components/MarketplaceFilter.tsx
+++ b/frontend/components/MarketplaceFilter.tsx
@@ -112,12 +112,57 @@ export default function MarketplaceFilter({ filters, onChange, resultCount }: Pr
     return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
   }, [localSearch]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Close modal on Escape
+  // Focus trap, Escape close, and return focus on close for Mobile Filter Modal
   useEffect(() => {
     if (!mobileOpen) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setMobileOpen(false); };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
+
+    const trigger = document.activeElement as HTMLElement | null;
+
+    // Focus the close button or first focusable element inside the modal
+    const focusable = modalRef.current?.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    if (focusable && focusable.length > 0) {
+      requestAnimationFrame(() => {
+        focusable[0].focus();
+      });
+    }
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setMobileOpen(false);
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      const focusableElements = modalRef.current?.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (!focusableElements || focusableElements.length === 0) return;
+
+      const first = focusableElements[0];
+      const last = focusableElements[focusableElements.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      requestAnimationFrame(() => {
+        trigger?.focus();
+      });
+    };
   }, [mobileOpen]);
 
   const handleClear = () => {


### PR DESCRIPTION
Closes #352 The Carbon Marketplace page had several accessibility limitations that prevented full operation using keyboard controls alone:

Keyboard focus could escape the mobile filter modal into background elements (violating WCAG focus trapping requirements).
Focus did not return to the triggering element (the filter button) when the mobile modal closed.
Listing card "Buy now" action links were not activatable via the Space key (which is standard behavior expected of button-like UI elements).
Reusable CreditCard button components lacked explicit keyboard overrides to ensure reliable event propagation and block default page behaviors (like page scrolling on Space key).
These issues violated WCAG 2.1 AA requirements and degraded usability for enterprise users relying on keyboard navigation.

Solution
Unified Mobile Modal Focus Trap & Restoration:

Modified 
MarketplaceFilter.tsx
 to query focusable children and trap keyboard focus cycling (Tab / Shift+Tab) inside the mobile filters modal.
Automatically save the element that had focus before the modal opened (the trigger button), and restore focus to it on close.
Resolved Escape key modal closure cleanly.
Custom Listing Card Keyboard Activation:

Updated 
page.tsx
 to intercept Space keydown events on the "Buy now" link and route client-side navigation appropriately.
Robust CreditCard Interactive Actions:

Modified 
CreditCard.tsx
 to add explicit onKeyDown listeners checking for Enter and Space on action buttons to prevent default scroll actions and ensure reliable triggers.
Verification & Testing
Natively verified focus outline visible focus rings (:focus-visible) remain functional and standard across all components.
Verified tab order is linear and logical.
Confirmed focus is securely trapped within the mobile filter modal and returns back to the filters trigger button upon closing the modal.
Verified both the "Buy now" links and CreditCard buttons trigger successfully when keyboard-operated (pressing Space or Enter).